### PR TITLE
Add tracepoints for PointCloudXyzrgbNode callback

### DIFF
--- a/depth_image_proc/CHANGELOG.rst
+++ b/depth_image_proc/CHANGELOG.rst
@@ -1,9 +1,27 @@
-2.0.0 (2018-12-09)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package depth_image_proc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+3.0.0 (2022-04-29)
 ------------------
-* enable rclcpp_register_node_plugins (`#368 <https://github.com/ros-perception/image_pipeline/issues/368>`_)
-* Port depth image proc on ROS2 (`#362 <https://github.com/ros-perception/image_pipeline/issues/362>`_)
-* Initial ROS2 commit.
-* Contributors: Chris Ye, Michael Carroll
+* Cleanup of depth_image_proc.
+* Fix linker error caused by templating in the conversions.cpp file (`#718 <https://github.com/ros-perception/image_pipeline/issues/718>`_)
+* Port upsampling interpolation from `#363 <https://github.com/ros-perception/image_pipeline/issues/363>`_ to ROS2 (`#692 <https://github.com/ros-perception/image_pipeline/issues/692>`_)
+* Fix uncrustify errors
+* allow loading depth_image_proc::RegisterNode as a component
+* Replace deprecated geometry2 headers
+* Fixed typo in pointcloudxyz launch file
+* use unique_ptrs, remove unused code, add back in missing initMatrix call
+* add xyzrgb radial node
+* Use RCLCPP_WARN_THROTTLE (10 secs) to avoid terminal spam
+* Fix tiny error in comment
+* Warning instead of fatal error when frames are differents
+* revert a293252
+* Replace deprecated geometry2 headers
+* Add maintainer (`#667 <https://github.com/ros-perception/image_pipeline/issues/667>`_)
+* move to hpp/cpp structure, create conversions file
+* Fix deprecation warning calling declare_parameter
+* Contributors: Chris Lalancette, Evan Flynn, Francisco Martin Rico, Francisco Martín Rico, Harshal Deshpande, Jacob Perron, Joe Schornak, Joseph Schornak, Joshua Whitley, Patrick Musau
 
 2.2.1 (2020-08-27)
 ------------------
@@ -48,6 +66,13 @@
   they appear to be OK.
   * fix linting
 * Contributors: Michael Ferguson
+
+2.0.0 (2018-12-09)
+------------------
+* enable rclcpp_register_node_plugins (`#368 <https://github.com/ros-perception/image_pipeline/issues/368>`_)
+* Port depth image proc on ROS2 (`#362 <https://github.com/ros-perception/image_pipeline/issues/362>`_)
+* Initial ROS2 commit.
+* Contributors: Chris Ye, Michael Carroll
 
 1.12.23 (2018-05-10)
 --------------------

--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -32,6 +32,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/point_cloud_xyzi.cpp
   src/point_cloud_xyz_radial.cpp
   src/point_cloud_xyzi_radial.cpp
+  src/point_cloud_xyzrgb_radial.cpp
   src/register.cpp
 )
 
@@ -44,6 +45,7 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "${PROJECT_NAME}::PointCloudXyziNode"
   "${PROJECT_NAME}::PointCloudXyziRadialNode"
   "${PROJECT_NAME}::PointCloudXyzrgbNode"
+  "${PROJECT_NAME}::PointCloudXyzrgbRadialNode"
   "${PROJECT_NAME}::RegisterNode"
 )
 

--- a/depth_image_proc/CMakeLists.txt
+++ b/depth_image_proc/CMakeLists.txt
@@ -36,6 +36,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/register.cpp
 )
 
+ament_target_dependencies(${PROJECT_NAME} tracetools_image_pipeline)
+
 rclcpp_components_register_nodes(${PROJECT_NAME}
   "${PROJECT_NAME}::ConvertMetricNode"
   "${PROJECT_NAME}::CropForemostNode"

--- a/depth_image_proc/include/depth_image_proc/conversions.hpp
+++ b/depth_image_proc/include/depth_image_proc/conversions.hpp
@@ -29,15 +29,20 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__CONVERSIONS_HPP_
 #define DEPTH_IMAGE_PROC__CONVERSIONS_HPP_
 
-#include <sensor_msgs/msg/image.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <image_geometry/pinhole_camera_model.h>
-#include <depth_image_proc/depth_traits.hpp>
-
 #include <limits>
+
+#include "image_geometry/pinhole_camera_model.h"
+
+#include <opencv2/core/mat.hpp>
+
+#include <depth_image_proc/depth_traits.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace depth_image_proc
 {
@@ -48,20 +53,94 @@ void convertDepth(
   const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
   sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
   const image_geometry::PinholeCameraModel & model,
-  double range_max = 0.0);
+  double range_max = 0.0)
+{
+  // Use correct principal point from calibration
+  float center_x = model.cx();
+  float center_y = model.cy();
+
+  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
+  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
+  float constant_x = unit_scaling / model.fx();
+  float constant_y = unit_scaling / model.fy();
+  float bad_point = std::numeric_limits<float>::quiet_NaN();
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
+  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
+  int row_step = depth_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
+      T depth = depth_row[u];
+
+      // Missing points denoted by NaNs
+      if (!DepthTraits<T>::valid(depth)) {
+        if (range_max != 0.0) {
+          depth = DepthTraits<T>::fromMeters(range_max);
+        } else {
+          *iter_x = *iter_y = *iter_z = bad_point;
+          continue;
+        }
+      }
+
+      // Fill in XYZ
+      *iter_x = (u - center_x) * depth * constant_x;
+      *iter_y = (v - center_y) * depth * constant_y;
+      *iter_z = DepthTraits<T>::toMeters(depth);
+    }
+  }
+}
 
 // Handles float or uint16 depths
 template<typename T>
 void convertDepthRadial(
   const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
   sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
-  cv::Mat & transform);
+  cv::Mat & transform)
+{
+  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
+  float bad_point = std::numeric_limits<float>::quiet_NaN();
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
+  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
+  int row_step = depth_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
+      T depth = depth_row[u];
+
+      // Missing points denoted by NaNs
+      if (!DepthTraits<T>::valid(depth)) {
+        *iter_x = *iter_y = *iter_z = bad_point;
+        continue;
+      }
+      const cv::Vec3f & cvPoint = transform.at<cv::Vec3f>(u, v) * DepthTraits<T>::toMeters(depth);
+      // Fill in XYZ
+      *iter_x = cvPoint(0);
+      *iter_y = cvPoint(1);
+      *iter_z = cvPoint(2);
+    }
+  }
+}
 
 // Handles float or uint16 depths
 template<typename T>
 void convertIntensity(
   const sensor_msgs::msg::Image::ConstSharedPtr & intensity_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg);
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg)
+{
+  sensor_msgs::PointCloud2Iterator<float> iter_i(*cloud_msg, "intensity");
+  const T * inten_row = reinterpret_cast<const T *>(&intensity_msg->data[0]);
+
+  const int i_row_step = intensity_msg->step / sizeof(T);
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, inten_row += i_row_step) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_i) {
+      *iter_i = inten_row[u];
+    }
+  }
+}
 
 // Handles RGB8, BGR8, and MONO8
 void convertRgb(

--- a/depth_image_proc/include/depth_image_proc/depth_traits.hpp
+++ b/depth_image_proc/include/depth_image_proc/depth_traits.hpp
@@ -29,12 +29,13 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__DEPTH_TRAITS_HPP_
 #define DEPTH_IMAGE_PROC__DEPTH_TRAITS_HPP_
 
 #include <algorithm>
-#include <limits>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyz.hpp
@@ -29,18 +29,24 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_HPP_
 #define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_HPP_
+
+#include <mutex>
+
+#include "depth_image_proc/visibility.h"
+#include "image_geometry/pinhole_camera_model.h"
 
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include <image_geometry/pinhole_camera_model.h>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/visibility.h>
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <memory>
 
 namespace depth_image_proc
 {
@@ -72,8 +78,6 @@ private:
   void depthCb(
     const Image::ConstSharedPtr & depth_msg,
     const CameraInfo::ConstSharedPtr & info_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzNode");
 };
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyz_radial.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyz_radial.hpp
@@ -29,25 +29,26 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_RADIAL_HPP_
 #define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZ_RADIAL_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.hpp>
-#include <sensor_msgs/image_encodings.hpp>
-#include <image_geometry/pinhole_camera_model.h>
-#include <depth_image_proc/depth_traits.hpp>
-#include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/visibility.h>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <memory>
+#include <array>
+#include <mutex>
 #include <vector>
-#include <limits>
+
+#include "depth_image_proc/visibility.h"
+#include "image_geometry/pinhole_camera_model.h"
+
+#include <image_transport/image_transport.hpp>
+#include <opencv2/core/mat.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace depth_image_proc
 {
-
-namespace enc = sensor_msgs::image_encodings;
 
 class PointCloudXyzRadialNode : public rclcpp::Node
 {
@@ -77,8 +78,6 @@ private:
   void depthCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyzRadialNode");
 };
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzi.hpp
@@ -29,27 +29,24 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_HPP_
 #define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.hpp>
-#include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <sensor_msgs/image_encodings.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <image_geometry/pinhole_camera_model.h>
-#include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/depth_traits.hpp>
-#include <depth_image_proc/visibility.h>
-#include <cv_bridge/cv_bridge.h>
-#include <opencv2/imgproc/imgproc.hpp>
 #include <memory>
-#include <string>
-#include <limits>
+#include <mutex>
+
+#include "depth_image_proc/visibility.h"
+#include "image_geometry/pinhole_camera_model.h"
+#include "message_filters/subscriber.h"
+#include "message_filters/sync_policies/approximate_time.h"
+#include "message_filters/synchronizer.h"
+
+#include <image_transport/subscriber_filter.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace depth_image_proc
 {
@@ -86,8 +83,6 @@ private:
     const Image::ConstSharedPtr & depth_msg,
     const Image::ConstSharedPtr & intensity_msg,
     const CameraInfo::ConstSharedPtr & info_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyziNode");
 };
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzi_radial.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzi_radial.hpp
@@ -29,30 +29,30 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_RADIAL_HPP_
 #define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZI_RADIAL_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.hpp>
-#include <sensor_msgs/image_encodings.hpp>
-#include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <image_geometry/pinhole_camera_model.h>
-#include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/depth_traits.hpp>
-#include <depth_image_proc/visibility.h>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <array>
 #include <memory>
+#include <mutex>
 #include <vector>
-#include <string>
-#include <limits>
+
+#include "depth_image_proc/visibility.h"
+#include "message_filters/subscriber.h"
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/exact_time.h"
+
+#include <image_transport/subscriber_filter.hpp>
+#include <opencv2/core/mat.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace depth_image_proc
 {
 
-namespace enc = sensor_msgs::image_encodings;
 using SyncPolicy =
   message_filters::sync_policies::ExactTime<
   sensor_msgs::msg::Image,
@@ -96,8 +96,6 @@ private:
     const Image::ConstSharedPtr & depth_msg,
     const Image::ConstSharedPtr & intensity_msg_in,
     const CameraInfo::ConstSharedPtr & info_msg);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("PointCloudXyziRadialNode");
 };
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb.hpp
@@ -87,6 +87,11 @@ private:
     const Image::ConstSharedPtr & depth_msg,
     const Image::ConstSharedPtr & rgb_msg,
     const CameraInfo::ConstSharedPtr & info_msg);
+
+  // Message serialization
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
 };
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb_radial.hpp
+++ b/depth_image_proc/include/depth_image_proc/point_cloud_xyzrgb_radial.hpp
@@ -30,11 +30,13 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_
-#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_
+#ifndef DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_RADIAL_HPP_
+#define DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_RADIAL_HPP_
 
+#include <array>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #include "depth_image_proc/visibility.h"
 #include "image_geometry/pinhole_camera_model.h"
@@ -43,9 +45,11 @@
 #include "message_filters/sync_policies/exact_time.h"
 #include "message_filters/sync_policies/approximate_time.h"
 
+#include <opencv2/core/mat.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -53,10 +57,10 @@
 namespace depth_image_proc
 {
 
-class PointCloudXyzrgbNode : public rclcpp::Node
+class PointCloudXyzrgbRadialNode : public rclcpp::Node
 {
 public:
-  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzrgbNode(const rclcpp::NodeOptions & options);
+  DEPTH_IMAGE_PROC_PUBLIC PointCloudXyzrgbRadialNode(const rclcpp::NodeOptions & options);
 
 private:
   using PointCloud2 = sensor_msgs::msg::PointCloud2;
@@ -72,12 +76,20 @@ private:
     message_filters::sync_policies::ExactTime<Image, Image, CameraInfo>;
   using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
   using ExactSynchronizer = message_filters::Synchronizer<ExactSyncPolicy>;
-  std::shared_ptr<Synchronizer> sync_;
-  std::shared_ptr<ExactSynchronizer> exact_sync_;
+  std::unique_ptr<Synchronizer> sync_;
+  std::unique_ptr<ExactSynchronizer> exact_sync_;
 
   // Publications
   std::mutex connect_mutex_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_point_cloud_;
+
+  std::vector<double> D_;
+  std::array<double, 9> K_;
+
+  uint32_t width_;
+  uint32_t height_;
+
+  cv::Mat transform_;
 
   image_geometry::PinholeCameraModel model_;
 
@@ -91,4 +103,4 @@ private:
 
 }  // namespace depth_image_proc
 
-#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_HPP_
+#endif  // DEPTH_IMAGE_PROC__POINT_CLOUD_XYZRGB_RADIAL_HPP_

--- a/depth_image_proc/launch/point_cloud_xyzrgb_radial.launch.py
+++ b/depth_image_proc/launch/point_cloud_xyzrgb_radial.launch.py
@@ -30,9 +30,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# uncomment if you want to launch rviz too in this launch
+# import os
+# from ament_index_python.packages import get_package_share_directory
 import os
 
 from ament_index_python.packages import get_package_share_directory
+import launch
 from launch import LaunchDescription
 
 import launch_ros.actions
@@ -41,14 +45,23 @@ import launch_ros.descriptions
 
 def generate_launch_description():
     default_rviz = os.path.join(get_package_share_directory('depth_image_proc'),
-                                'launch', 'rviz/point_cloud_xyz.rviz')
+                                'launch', 'rviz/point_cloud_xyzrgb.rviz')
     return LaunchDescription([
-        # install realsense from https://github.com/intel/ros2_intel_realsense
+        launch.actions.DeclareLaunchArgument(
+            name='rviz', default_value='False',
+            description='Launch RViz for viewing point cloud xyzrgb radial data'
+        ),
         launch_ros.actions.Node(
-            package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
-            output='screen'),
-
+            condition=launch.conditions.IfCondition(
+                launch.substitutions.LaunchConfiguration('rviz')
+            ),
+            package='rviz2',
+            executable='rviz2',
+            output='screen',
+            arguments=['--display-config', default_rviz]
+        ),
         # launch plugin through rclcpp_components container
+        # make sure remapped topics are available
         launch_ros.actions.ComposableNodeContainer(
             name='container',
             namespace='',
@@ -58,18 +71,20 @@ def generate_launch_description():
                 # Driver itself
                 launch_ros.descriptions.ComposableNode(
                     package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_node',
-                    remappings=[('image_rect', '/camera/depth/image_rect_raw'),
-                                ('camera_info', '/camera/depth/camera_info'),
-                                ('image', '/camera/depth/converted_image')]
+                    plugin='depth_image_proc::PointCloudXyzrgbRadialNode',
+                    name='point_cloud_xyzrgb_node',
+                    remappings=[('rgb/camera_info', '/camera/color/camera_info'),
+                                ('rgb/image_rect_color', '/camera/color/image_raw'),
+                                ('depth_registered/image_rect',
+                                 '/camera/aligned_depth_to_color/image_raw'),
+                                ('points', '/camera/depth_registered/points')]
                 ),
             ],
             output='screen',
         ),
 
         # rviz
-        launch_ros.actions.Node(
-            package='rviz2', node_executable='rviz2', output='screen',
-            arguments=['--display-config', default_rviz]),
+        # launch_ros.actions.Node(
+        #    package='rviz2', executable='rviz2', output='screen',
+        #    arguments=['--display-config', default_rviz]),
     ])

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depth_image_proc</name>
-  <version>2.2.1</version>
+  <version>3.0.0</version>
   <description>
 
      Contains components for processing depth images such as those
@@ -25,12 +25,13 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>message_filters</build_depend>
   <build_depend>class_loader</build_depend>
 
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>
   <depend>image_transport</depend>
+  <depend>libopencv-dev</depend>
+  <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/depth_image_proc/package.xml
+++ b/depth_image_proc/package.xml
@@ -39,6 +39,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
+  <depend>tracetools_image_pipeline</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/depth_image_proc/src/conversions.cpp
+++ b/depth_image_proc/src/conversions.cpp
@@ -29,7 +29,7 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "depth_image_proc/conversions.hpp"
+#include <depth_image_proc/conversions.hpp>
 
 #include <limits>
 #include <vector>
@@ -37,123 +37,9 @@
 namespace depth_image_proc
 {
 
-// Handles float or uint16 depths
-template<typename T>
-void convertDepth(
-  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
-  const image_geometry::PinholeCameraModel & model,
-  double range_max)
-{
-  // Use correct principal point from calibration
-  float center_x = model.cx();
-  float center_y = model.cy();
-
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  double unit_scaling = DepthTraits<T>::toMeters(T(1) );
-  float constant_x = unit_scaling / model.fx();
-  float constant_y = unit_scaling / model.fy();
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
-      T depth = depth_row[u];
-
-      // Missing points denoted by NaNs
-      if (!DepthTraits<T>::valid(depth)) {
-        if (range_max != 0.0) {
-          depth = DepthTraits<T>::fromMeters(range_max);
-        } else {
-          *iter_x = *iter_y = *iter_z = bad_point;
-          continue;
-        }
-      }
-
-      // Fill in XYZ
-      *iter_x = (u - center_x) * depth * constant_x;
-      *iter_y = (v - center_y) * depth * constant_y;
-      *iter_z = DepthTraits<T>::toMeters(depth);
-    }
-  }
-}
-
-// Handles float or uint16 depths
-template<typename T>
-void convertDepthRadial(
-  const sensor_msgs::msg::Image::ConstSharedPtr & depth_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
-  cv::Mat & transform)
-{
-  // Combine unit conversion (if necessary) with scaling by focal length for computing (X,Y)
-  float bad_point = std::numeric_limits<float>::quiet_NaN();
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud_msg, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud_msg, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud_msg, "z");
-  const T * depth_row = reinterpret_cast<const T *>(&depth_msg->data[0]);
-  int row_step = depth_msg->step / sizeof(T);
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, depth_row += row_step) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_x, ++iter_y, ++iter_z) {
-      T depth = depth_row[u];
-
-      // Missing points denoted by NaNs
-      if (!DepthTraits<T>::valid(depth)) {
-        *iter_x = *iter_y = *iter_z = bad_point;
-        continue;
-      }
-      const cv::Vec3f & cvPoint = transform.at<cv::Vec3f>(u, v) * DepthTraits<T>::toMeters(depth);
-      // Fill in XYZ
-      *iter_x = cvPoint(0);
-      *iter_y = cvPoint(1);
-      *iter_z = cvPoint(2);
-    }
-  }
-}
-
-// Handles float or uint16 depths
-template<typename T>
-void convertIntensity(
-  const sensor_msgs::msg::Image::ConstSharedPtr & intensity_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg)
-{
-  sensor_msgs::PointCloud2Iterator<float> iter_i(*cloud_msg, "intensity");
-  const T * inten_row = reinterpret_cast<const T *>(&intensity_msg->data[0]);
-
-  const int i_row_step = intensity_msg->step / sizeof(T);
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, inten_row += i_row_step) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u, ++iter_i) {
-      *iter_i = inten_row[u];
-    }
-  }
-}
-
-void convertRgb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
-  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
-  int red_offset, int green_offset, int blue_offset, int color_step)
-{
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_r(*cloud_msg, "r");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_g(*cloud_msg, "g");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_b(*cloud_msg, "b");
-  const uint8_t * rgb = &rgb_msg->data[0];
-  int rgb_skip = rgb_msg->step - rgb_msg->width * color_step;
-  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, rgb += rgb_skip) {
-    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u,
-      rgb += color_step, ++iter_r, ++iter_g, ++iter_b)
-    {
-      *iter_r = rgb[red_offset];
-      *iter_g = rgb[green_offset];
-      *iter_b = rgb[blue_offset];
-    }
-  }
-}
-
-cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int height, bool radial)
+cv::Mat initMatrix(
+  cv::Mat cameraMatrix, cv::Mat distCoeffs,
+  int width, int height, bool radial)
 {
   int i, j;
   int totalsize = width * height;
@@ -191,4 +77,24 @@ cv::Mat initMatrix(cv::Mat cameraMatrix, cv::Mat distCoeffs, int width, int heig
   return pixelVectors.reshape(3, width);
 }
 
+void convertRgb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & rgb_msg,
+  sensor_msgs::msg::PointCloud2::SharedPtr & cloud_msg,
+  int red_offset, int green_offset, int blue_offset, int color_step)
+{
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_r(*cloud_msg, "r");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_g(*cloud_msg, "g");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_b(*cloud_msg, "b");
+  const uint8_t * rgb = &rgb_msg->data[0];
+  int rgb_skip = rgb_msg->step - rgb_msg->width * color_step;
+  for (int v = 0; v < static_cast<int>(cloud_msg->height); ++v, rgb += rgb_skip) {
+    for (int u = 0; u < static_cast<int>(cloud_msg->width); ++u,
+      rgb += color_step, ++iter_r, ++iter_g, ++iter_b)
+    {
+      *iter_r = rgb[red_offset];
+      *iter_g = rgb[green_offset];
+      *iter_b = rgb[blue_offset];
+    }
+  }
+}
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/crop_foremost.cpp
+++ b/depth_image_proc/src/crop_foremost.cpp
@@ -29,12 +29,16 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
+#include <functional>
+#include <mutex>
+
+#include "cv_bridge/cv_bridge.h"
+#include "depth_image_proc/visibility.h"
+
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
-#include <cv_bridge/cv_bridge.h>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <depth_image_proc/visibility.h>
-#include <memory>
 
 namespace depth_image_proc
 {

--- a/depth_image_proc/src/point_cloud_xyz.cpp
+++ b/depth_image_proc/src/point_cloud_xyz.cpp
@@ -29,16 +29,21 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "depth_image_proc/point_cloud_xyz.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "depth_image_proc/visibility.h"
+#include "image_geometry/pinhole_camera_model.h"
+
+#include <depth_image_proc/point_cloud_xyz.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/visibility.h>
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <memory>
 
 namespace depth_image_proc
 {
@@ -105,7 +110,8 @@ void PointCloudXyzNode::depthCb(
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
     convertDepth<float>(depth_msg, cloud_msg, model_);
   } else {
-    RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
+    RCLCPP_ERROR(
+      get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
     return;
   }
 

--- a/depth_image_proc/src/point_cloud_xyz_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyz_radial.cpp
@@ -29,26 +29,26 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "depth_image_proc/point_cloud_xyz_radial.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "image_geometry/pinhole_camera_model.h"
+
+#include <depth_image_proc/point_cloud_xyz_radial.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include <image_geometry/pinhole_camera_model.h>
 #include <depth_image_proc/depth_traits.hpp>
 #include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/visibility.h>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-
-#include <memory>
-#include <vector>
-#include <limits>
 
 namespace depth_image_proc
 {
 
 
 PointCloudXyzRadialNode::PointCloudXyzRadialNode(const rclcpp::NodeOptions & options)
-: Node("PointCloudXyzRadialNode", options)
+: rclcpp::Node("PointCloudXyzRadialNode", options)
 {
   // Read parameters
   queue_size_ = this->declare_parameter<int>("queue_size", 5);
@@ -114,12 +114,13 @@ void PointCloudXyzRadialNode::depthCb(
   }
 
   // Convert Depth Image to Pointcloud
-  if (depth_msg->encoding == enc::TYPE_16UC1) {
+  if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
     convertDepthRadial<uint16_t>(depth_msg, cloud_msg, transform_);
-  } else if (depth_msg->encoding == enc::TYPE_32FC1) {
+  } else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1) {
     convertDepthRadial<float>(depth_msg, cloud_msg, transform_);
   } else {
-    RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
+    RCLCPP_ERROR(
+      get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
     return;
   }
 

--- a/depth_image_proc/src/point_cloud_xyzi.cpp
+++ b/depth_image_proc/src/point_cloud_xyzi.cpp
@@ -29,33 +29,30 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "depth_image_proc/point_cloud_xyzi.hpp"
-#include <rclcpp/rclcpp.hpp>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "cv_bridge/cv_bridge.h"
+
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <sensor_msgs/image_encodings.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <image_geometry/pinhole_camera_model.h>
-#include <depth_image_proc/depth_traits.hpp>
 #include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/visibility.h>
-#include <cv_bridge/cv_bridge.h>
+#include <depth_image_proc/point_cloud_xyzi.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-
-#include <memory>
-#include <string>
-#include <limits>
 
 namespace depth_image_proc
 {
 
 
 PointCloudXyziNode::PointCloudXyziNode(const rclcpp::NodeOptions & options)
-: Node("PointCloudXyziNode", options)
+: rclcpp::Node("PointCloudXyziNode", options)
 {
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
@@ -117,10 +114,12 @@ void PointCloudXyziNode::imageCb(
 {
   // Check for bad inputs
   if (depth_msg->header.frame_id != intensity_msg_in->header.frame_id) {
-    RCLCPP_ERROR(
-      logger_, "Depth image frame id [%s] doesn't match image frame id [%s]",
+    RCLCPP_WARN_THROTTLE(
+      get_logger(),
+      *get_clock(),
+      10000,  // 10 seconds
+      "Depth image frame id [%s] doesn't match image frame id [%s]",
       depth_msg->header.frame_id.c_str(), intensity_msg_in->header.frame_id.c_str());
-    return;
   }
 
   // Update camera model
@@ -146,8 +145,8 @@ void PointCloudXyziNode::imageCb(
     cv_bridge::CvImageConstPtr cv_ptr;
     try {
       cv_ptr = cv_bridge::toCvShare(intensity_msg, intensity_msg->encoding);
-    } catch (cv_bridge::Exception & e) {
-      RCLCPP_ERROR(logger_, "cv_bridge exception: %s", e.what());
+    } catch (const cv_bridge::Exception & e) {
+      RCLCPP_ERROR(get_logger(), "cv_bridge exception: %s", e.what());
       return;
     }
     cv_bridge::CvImage cv_rsz;
@@ -162,7 +161,7 @@ void PointCloudXyziNode::imageCb(
       intensity_msg = cv_bridge::toCvCopy(cv_rsz.toImageMsg(), enc::MONO8)->toImageMsg();
     }
 
-    // RCLCPP_ERROR(logger_, "Depth resolution (%ux%u) does not match resolution (%ux%u)",
+    // RCLCPP_ERROR(get_logger(), "Depth resolution (%ux%u) does not match resolution (%ux%u)",
     //              depth_msg->width, depth_msg->height, rgb_msg->width, rgb_msg->height);
     // return;
   } else {
@@ -173,9 +172,9 @@ void PointCloudXyziNode::imageCb(
   if (intensity_msg->encoding != enc::MONO8 || intensity_msg->encoding != enc::MONO16) {
     try {
       intensity_msg = cv_bridge::toCvCopy(intensity_msg, enc::MONO8)->toImageMsg();
-    } catch (cv_bridge::Exception & e) {
+    } catch (const cv_bridge::Exception & e) {
       RCLCPP_ERROR(
-        logger_, "Unsupported encoding [%s]: %s",
+        get_logger(), "Unsupported encoding [%s]: %s",
         intensity_msg->encoding.c_str(), e.what());
       return;
     }
@@ -203,7 +202,8 @@ void PointCloudXyziNode::imageCb(
   } else if (depth_msg->encoding == enc::TYPE_32FC1) {
     convertDepth<float>(depth_msg, cloud_msg, model_);
   } else {
-    RCLCPP_ERROR(logger_, "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
+    RCLCPP_ERROR(
+      get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
     return;
   }
 
@@ -216,7 +216,8 @@ void PointCloudXyziNode::imageCb(
     convertIntensity<uint16_t>(intensity_msg, cloud_msg);
   } else {
     RCLCPP_ERROR(
-      logger_, "Intensity image has unsupported encoding [%s]", intensity_msg->encoding.c_str());
+      get_logger(), "Intensity image has unsupported encoding [%s]",
+      intensity_msg->encoding.c_str());
     return;
   }
 

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -132,8 +132,8 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*depth_msg)),
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
-    rgb_msg_in->header.stamp.nanosec,
-    rgb_msg_in->header.stamp.sec);
+    depth_msg->header.stamp.nanosec,
+    depth_msg->header.stamp.sec);
 
   // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
@@ -177,8 +177,8 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*depth_msg)),
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
-        rgb_msg_in->header.stamp.nanosec,
-        rgb_msg_in->header.stamp.sec);
+        depth_msg->header.stamp.nanosec,
+        depth_msg->header.stamp.sec);
 
       return;
     }
@@ -208,8 +208,8 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*depth_msg)),
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
-        rgb_msg_in->header.stamp.nanosec,
-        rgb_msg_in->header.stamp.sec);
+        depth_msg->header.stamp.nanosec,
+        depth_msg->header.stamp.sec);
   
     return;
   } else {
@@ -246,8 +246,8 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*depth_msg)),
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
-        rgb_msg_in->header.stamp.nanosec,
-        rgb_msg_in->header.stamp.sec);
+        depth_msg->header.stamp.nanosec,
+        depth_msg->header.stamp.sec);
 
       return;
     }
@@ -263,8 +263,8 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*depth_msg)),
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
-    rgb_msg_in->header.stamp.nanosec,
-    rgb_msg_in->header.stamp.sec);
+    depth_msg->header.stamp.nanosec,
+    depth_msg->header.stamp.sec);
 
   auto cloud_msg = std::make_shared<PointCloud2>();
   cloud_msg->header = depth_msg->header;  // Use depth image time stamp
@@ -291,8 +291,8 @@ void PointCloudXyzrgbNode::imageCb(
       static_cast<const void *>(&(*depth_msg)),
       static_cast<const void *>(&(*rgb_msg_in)),
       static_cast<const void *>(&(*info_msg)),
-      rgb_msg_in->header.stamp.nanosec,
-      rgb_msg_in->header.stamp.sec);
+      depth_msg->header.stamp.nanosec,
+      depth_msg->header.stamp.sec);
 
     TRACEPOINT(
         depth_image_proc_transform_to_pointcloud_cb_fini,
@@ -300,8 +300,8 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*depth_msg)),
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
-        rgb_msg_in->header.stamp.nanosec,
-        rgb_msg_in->header.stamp.sec);
+        depth_msg->header.stamp.nanosec,
+        depth_msg->header.stamp.sec);
 
     return;
   }
@@ -323,8 +323,8 @@ void PointCloudXyzrgbNode::imageCb(
       static_cast<const void *>(&(*depth_msg)),
       static_cast<const void *>(&(*rgb_msg_in)),
       static_cast<const void *>(&(*info_msg)),
-      rgb_msg_in->header.stamp.nanosec,
-      rgb_msg_in->header.stamp.sec);
+      depth_msg->header.stamp.nanosec,
+      depth_msg->header.stamp.sec);
 
     TRACEPOINT(
       depth_image_proc_transform_to_pointcloud_cb_fini,
@@ -332,8 +332,8 @@ void PointCloudXyzrgbNode::imageCb(
       static_cast<const void *>(&(*depth_msg)),
       static_cast<const void *>(&(*rgb_msg_in)),
       static_cast<const void *>(&(*info_msg)),
-      rgb_msg_in->header.stamp.nanosec,
-      rgb_msg_in->header.stamp.sec);
+      depth_msg->header.stamp.nanosec,
+      depth_msg->header.stamp.sec);
 
     return;
   }
@@ -344,8 +344,8 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*depth_msg)),
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
-    rgb_msg_in->header.stamp.nanosec,
-    rgb_msg_in->header.stamp.sec);
+    depth_msg->header.stamp.nanosec,
+    depth_msg->header.stamp.sec);
 
   pub_point_cloud_->publish(*cloud_msg);
 
@@ -355,8 +355,8 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*depth_msg)),
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
-    rgb_msg_in->header.stamp.nanosec,
-    rgb_msg_in->header.stamp.sec);
+    depth_msg->header.stamp.nanosec,
+    depth_msg->header.stamp.sec);
 }
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -35,6 +35,7 @@
 #include <mutex>
 #include <string>
 
+#include "tracetools_image_pipeline/tracetools.h"
 #include "cv_bridge/cv_bridge.h"
 
 #include <depth_image_proc/conversions.hpp>
@@ -124,6 +125,16 @@ void PointCloudXyzrgbNode::imageCb(
   const Image::ConstSharedPtr & rgb_msg_in,
   const CameraInfo::ConstSharedPtr & info_msg)
 {
+
+  TRACEPOINT(
+    depth_image_proc_transform_to_pointcloud_cb_init,
+    static_cast<const void *>(this),
+    static_cast<const void *>(&(*depth_msg)),
+    static_cast<const void *>(&(*rgb_msg_in)),
+    static_cast<const void *>(&(*info_msg)),
+    rgb_msg_in->header.stamp.nanosec,
+    rgb_msg_in->header.stamp.sec);
+
   // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
     RCLCPP_WARN_THROTTLE(
@@ -159,6 +170,16 @@ void PointCloudXyzrgbNode::imageCb(
       cv_ptr = cv_bridge::toCvShare(rgb_msg, rgb_msg->encoding);
     } catch (cv_bridge::Exception & e) {
       RCLCPP_ERROR(get_logger(), "cv_bridge exception: %s", e.what());
+
+      TRACEPOINT(
+        depth_image_proc_transform_to_pointcloud_cb_fini,
+        static_cast<const void *>(this),
+        static_cast<const void *>(&(*depth_msg)),
+        static_cast<const void *>(&(*rgb_msg_in)),
+        static_cast<const void *>(&(*info_msg)),
+        rgb_msg_in->header.stamp.nanosec,
+        rgb_msg_in->header.stamp.sec);
+
       return;
     }
     cv_bridge::CvImage cv_rsz;
@@ -180,6 +201,16 @@ void PointCloudXyzrgbNode::imageCb(
     RCLCPP_ERROR(
       get_logger(), "Depth resolution (%ux%u) does not match RGB resolution (%ux%u)",
       depth_msg->width, depth_msg->height, rgb_msg->width, rgb_msg->height);
+
+    TRACEPOINT(
+        depth_image_proc_transform_to_pointcloud_cb_fini,
+        static_cast<const void *>(this),
+        static_cast<const void *>(&(*depth_msg)),
+        static_cast<const void *>(&(*rgb_msg_in)),
+        static_cast<const void *>(&(*info_msg)),
+        rgb_msg_in->header.stamp.nanosec,
+        rgb_msg_in->header.stamp.sec);
+  
     return;
   } else {
     rgb_msg = rgb_msg_in;
@@ -208,6 +239,16 @@ void PointCloudXyzrgbNode::imageCb(
     } catch (cv_bridge::Exception & e) {
       RCLCPP_ERROR(
         get_logger(), "Unsupported encoding [%s]: %s", rgb_msg->encoding.c_str(), e.what());
+
+      TRACEPOINT(
+        depth_image_proc_transform_to_pointcloud_cb_fini,
+        static_cast<const void *>(this),
+        static_cast<const void *>(&(*depth_msg)),
+        static_cast<const void *>(&(*rgb_msg_in)),
+        static_cast<const void *>(&(*info_msg)),
+        rgb_msg_in->header.stamp.nanosec,
+        rgb_msg_in->header.stamp.sec);
+
       return;
     }
     red_offset = 0;
@@ -215,6 +256,15 @@ void PointCloudXyzrgbNode::imageCb(
     blue_offset = 2;
     color_step = 3;
   }
+
+  TRACEPOINT(
+    depth_image_proc_transform_to_pointcloud_init,
+    static_cast<const void *>(this),
+    static_cast<const void *>(&(*depth_msg)),
+    static_cast<const void *>(&(*rgb_msg_in)),
+    static_cast<const void *>(&(*info_msg)),
+    rgb_msg_in->header.stamp.nanosec,
+    rgb_msg_in->header.stamp.sec);
 
   auto cloud_msg = std::make_shared<PointCloud2>();
   cloud_msg->header = depth_msg->header;  // Use depth image time stamp
@@ -234,6 +284,25 @@ void PointCloudXyzrgbNode::imageCb(
   } else {
     RCLCPP_ERROR(
       get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
+
+    TRACEPOINT(
+      depth_image_proc_transform_to_pointcloud_fini,
+      static_cast<const void *>(this),
+      static_cast<const void *>(&(*depth_msg)),
+      static_cast<const void *>(&(*rgb_msg_in)),
+      static_cast<const void *>(&(*info_msg)),
+      rgb_msg_in->header.stamp.nanosec,
+      rgb_msg_in->header.stamp.sec);
+
+    TRACEPOINT(
+        depth_image_proc_transform_to_pointcloud_cb_fini,
+        static_cast<const void *>(this),
+        static_cast<const void *>(&(*depth_msg)),
+        static_cast<const void *>(&(*rgb_msg_in)),
+        static_cast<const void *>(&(*info_msg)),
+        rgb_msg_in->header.stamp.nanosec,
+        rgb_msg_in->header.stamp.sec);
+
     return;
   }
 
@@ -247,10 +316,47 @@ void PointCloudXyzrgbNode::imageCb(
   } else {
     RCLCPP_ERROR(
       get_logger(), "RGB image has unsupported encoding [%s]", rgb_msg->encoding.c_str());
+
+    TRACEPOINT(
+      depth_image_proc_transform_to_pointcloud_fini,
+      static_cast<const void *>(this),
+      static_cast<const void *>(&(*depth_msg)),
+      static_cast<const void *>(&(*rgb_msg_in)),
+      static_cast<const void *>(&(*info_msg)),
+      rgb_msg_in->header.stamp.nanosec,
+      rgb_msg_in->header.stamp.sec);
+
+    TRACEPOINT(
+      depth_image_proc_transform_to_pointcloud_cb_fini,
+      static_cast<const void *>(this),
+      static_cast<const void *>(&(*depth_msg)),
+      static_cast<const void *>(&(*rgb_msg_in)),
+      static_cast<const void *>(&(*info_msg)),
+      rgb_msg_in->header.stamp.nanosec,
+      rgb_msg_in->header.stamp.sec);
+
     return;
   }
 
+  TRACEPOINT(
+    depth_image_proc_transform_to_pointcloud_fini,
+    static_cast<const void *>(this),
+    static_cast<const void *>(&(*depth_msg)),
+    static_cast<const void *>(&(*rgb_msg_in)),
+    static_cast<const void *>(&(*info_msg)),
+    rgb_msg_in->header.stamp.nanosec,
+    rgb_msg_in->header.stamp.sec);
+
   pub_point_cloud_->publish(*cloud_msg);
+
+  TRACEPOINT(
+    depth_image_proc_transform_to_pointcloud_cb_fini,
+    static_cast<const void *>(this),
+    static_cast<const void *>(&(*depth_msg)),
+    static_cast<const void *>(&(*rgb_msg_in)),
+    static_cast<const void *>(&(*info_msg)),
+    rgb_msg_in->header.stamp.nanosec,
+    rgb_msg_in->header.stamp.sec);
 }
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyzrgb.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb.cpp
@@ -43,6 +43,7 @@
 #include <image_transport/image_transport.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 namespace depth_image_proc
@@ -94,6 +95,25 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
   // TODO(ros2) Implement connect_cb when SubscriberStatusCallback is available
 }
 
+size_t PointCloudXyzrgbNode::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.size();
+  return image_msg_size;
+}
+
+size_t PointCloudXyzrgbNode::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
 // Handles (un)subscribing when clients (un)subscribe
 void PointCloudXyzrgbNode::connectCb()
 {
@@ -133,7 +153,10 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
     depth_msg->header.stamp.nanosec,
-    depth_msg->header.stamp.sec);
+    depth_msg->header.stamp.sec,
+    get_msg_size(depth_msg),
+    get_msg_size(rgb_msg_in),
+    get_msg_size(info_msg));
 
   // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
@@ -178,7 +201,10 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
         depth_msg->header.stamp.nanosec,
-        depth_msg->header.stamp.sec);
+        depth_msg->header.stamp.sec,
+        get_msg_size(depth_msg),
+        get_msg_size(rgb_msg_in),
+        get_msg_size(info_msg));
 
       return;
     }
@@ -209,7 +235,10 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
         depth_msg->header.stamp.nanosec,
-        depth_msg->header.stamp.sec);
+        depth_msg->header.stamp.sec,
+        get_msg_size(depth_msg),
+        get_msg_size(rgb_msg_in),
+        get_msg_size(info_msg));
   
     return;
   } else {
@@ -247,7 +276,10 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
         depth_msg->header.stamp.nanosec,
-        depth_msg->header.stamp.sec);
+        depth_msg->header.stamp.sec,
+        get_msg_size(depth_msg),
+        get_msg_size(rgb_msg_in),
+        get_msg_size(info_msg));
 
       return;
     }
@@ -301,7 +333,10 @@ void PointCloudXyzrgbNode::imageCb(
         static_cast<const void *>(&(*rgb_msg_in)),
         static_cast<const void *>(&(*info_msg)),
         depth_msg->header.stamp.nanosec,
-        depth_msg->header.stamp.sec);
+        depth_msg->header.stamp.sec,
+        get_msg_size(depth_msg),
+        get_msg_size(rgb_msg_in),
+        get_msg_size(info_msg));
 
     return;
   }
@@ -333,7 +368,10 @@ void PointCloudXyzrgbNode::imageCb(
       static_cast<const void *>(&(*rgb_msg_in)),
       static_cast<const void *>(&(*info_msg)),
       depth_msg->header.stamp.nanosec,
-      depth_msg->header.stamp.sec);
+      depth_msg->header.stamp.sec,
+      get_msg_size(depth_msg),
+      get_msg_size(rgb_msg_in),
+      get_msg_size(info_msg));
 
     return;
   }
@@ -356,7 +394,10 @@ void PointCloudXyzrgbNode::imageCb(
     static_cast<const void *>(&(*rgb_msg_in)),
     static_cast<const void *>(&(*info_msg)),
     depth_msg->header.stamp.nanosec,
-    depth_msg->header.stamp.sec);
+    depth_msg->header.stamp.sec,
+    get_msg_size(depth_msg),
+    get_msg_size(rgb_msg_in),
+    get_msg_size(info_msg));
 }
 
 }  // namespace depth_image_proc

--- a/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
+++ b/depth_image_proc/src/point_cloud_xyzrgb_radial.cpp
@@ -38,18 +38,21 @@
 #include "cv_bridge/cv_bridge.h"
 
 #include <depth_image_proc/conversions.hpp>
-#include <depth_image_proc/point_cloud_xyzrgb.hpp>
+#include <depth_image_proc/point_cloud_xyzrgb_radial.hpp>
 #include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace depth_image_proc
 {
 
 
-PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
-: rclcpp::Node("PointCloudXyzrgbNode", options)
+PointCloudXyzrgbRadialNode::PointCloudXyzrgbRadialNode(const rclcpp::NodeOptions & options)
+: Node("PointCloudXyzrgbRadialNode", options)
 {
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
@@ -57,23 +60,24 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
 
   // Synchronize inputs. Topic subscriptions happen on demand in the connection callback.
   if (use_exact_sync) {
-    exact_sync_ = std::make_shared<ExactSynchronizer>(
+    exact_sync_ = std::make_unique<ExactSynchronizer>(
       ExactSyncPolicy(queue_size),
       sub_depth_,
       sub_rgb_,
       sub_info_);
     exact_sync_->registerCallback(
       std::bind(
-        &PointCloudXyzrgbNode::imageCb,
+        &PointCloudXyzrgbRadialNode::imageCb,
         this,
         std::placeholders::_1,
         std::placeholders::_2,
         std::placeholders::_3));
   } else {
-    sync_ = std::make_shared<Synchronizer>(SyncPolicy(queue_size), sub_depth_, sub_rgb_, sub_info_);
+    sync_ =
+      std::make_unique<Synchronizer>(SyncPolicy(queue_size), sub_depth_, sub_rgb_, sub_info_);
     sync_->registerCallback(
       std::bind(
-        &PointCloudXyzrgbNode::imageCb,
+        &PointCloudXyzrgbRadialNode::imageCb,
         this,
         std::placeholders::_1,
         std::placeholders::_2,
@@ -82,11 +86,12 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
 
   // Monitor whether anyone is subscribed to the output
   // TODO(ros2) Implement when SubscriberStatusCallback is available
-  // ros::SubscriberStatusCallback connect_cb = boost::bind(&PointCloudXyzrgbNode::connectCb, this);
+  // ros::SubscriberStatusCallback connect_cb =
+  //   boost::bind(&PointCloudXyzrgbRadialNode::connectCb, this);
   connectCb();
   // TODO(ros2) Implement when SubscriberStatusCallback is available
   // Make sure we don't enter connectCb() between advertising and assigning to pub_point_cloud_
-  std::lock_guard<std::mutex> lock(connect_mutex_);
+  // std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement connect_cb when SubscriberStatusCallback is available
   // pub_point_cloud_ = depth_nh.advertise<PointCloud>("points", 1, connect_cb, connect_cb);
   pub_point_cloud_ = create_publisher<PointCloud2>("points", rclcpp::SensorDataQoS());
@@ -94,7 +99,7 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions & options)
 }
 
 // Handles (un)subscribing when clients (un)subscribe
-void PointCloudXyzrgbNode::connectCb()
+void PointCloudXyzrgbRadialNode::connectCb()
 {
   std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement getNumSubscribers when rcl/rmw support it
@@ -119,19 +124,17 @@ void PointCloudXyzrgbNode::connectCb()
   }
 }
 
-void PointCloudXyzrgbNode::imageCb(
+void PointCloudXyzrgbRadialNode::imageCb(
   const Image::ConstSharedPtr & depth_msg,
   const Image::ConstSharedPtr & rgb_msg_in,
   const CameraInfo::ConstSharedPtr & info_msg)
 {
   // Check for bad inputs
   if (depth_msg->header.frame_id != rgb_msg_in->header.frame_id) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(),
-      *get_clock(),
-      10000,  // 10 seconds
-      "Depth image frame id [%s] doesn't match RGB image frame id [%s]",
+    RCLCPP_WARN(
+      get_logger(), "Depth image frame id [%s] doesn't match RGB image frame id [%s]",
       depth_msg->header.frame_id.c_str(), rgb_msg_in->header.frame_id.c_str());
+    return;
   }
 
   // Update camera model
@@ -185,6 +188,16 @@ void PointCloudXyzrgbNode::imageCb(
     rgb_msg = rgb_msg_in;
   }
 
+  if (info_msg->d != D_ || info_msg->k != K_ || width_ != info_msg->width ||
+    height_ != info_msg->height)
+  {
+    D_ = info_msg->d;
+    K_ = info_msg->k;
+    width_ = info_msg->width;
+    height_ = info_msg->height;
+    transform_ = initMatrix(cv::Mat_<double>(3, 3, &K_[0]), cv::Mat(D_), width_, height_, true);
+  }
+
   // Supported color encodings: RGB8, BGR8, MONO8
   int red_offset, green_offset, blue_offset, color_step;
   if (rgb_msg->encoding == sensor_msgs::image_encodings::RGB8) {
@@ -228,9 +241,9 @@ void PointCloudXyzrgbNode::imageCb(
 
   // Convert Depth Image to Pointcloud
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
-    convertDepth<uint16_t>(depth_msg, cloud_msg, model_);
+    convertDepthRadial<uint16_t>(depth_msg, cloud_msg, transform_);
   } else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1) {
-    convertDepth<float>(depth_msg, cloud_msg, model_);
+    convertDepthRadial<float>(depth_msg, cloud_msg, transform_);
   } else {
     RCLCPP_ERROR(
       get_logger(), "Depth image has unsupported encoding [%s]", depth_msg->encoding.c_str());
@@ -258,4 +271,4 @@ void PointCloudXyzrgbNode::imageCb(
 #include "rclcpp_components/register_node_macro.hpp"
 
 // Register the component with class_loader.
-RCLCPP_COMPONENTS_REGISTER_NODE(depth_image_proc::PointCloudXyzrgbNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(depth_image_proc::PointCloudXyzrgbRadialNode)

--- a/depth_image_proc/src/register.cpp
+++ b/depth_image_proc/src/register.cpp
@@ -29,32 +29,35 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "Eigen/Geometry"
+#include "depth_image_proc/visibility.h"
+#include "image_geometry/pinhole_camera_model.h"
+#include "message_filters/subscriber.h"
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/approximate_time.h"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 #include <sensor_msgs/image_encodings.hpp>
-#include <image_geometry/pinhole_camera_model.h>
-#include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <depth_image_proc/depth_traits.hpp>
-#include <depth_image_proc/visibility.h>
-#include <memory>
 
 namespace depth_image_proc
 {
 
-using namespace std::placeholders;
-namespace enc = sensor_msgs::image_encodings;
-
 class RegisterNode : public rclcpp::Node
 {
 public:
-  DEPTH_IMAGE_PROC_PUBLIC RegisterNode();
+  DEPTH_IMAGE_PROC_PUBLIC RegisterNode(const rclcpp::NodeOptions & options);
 
 private:
   using Image = sensor_msgs::msg::Image;
@@ -77,6 +80,9 @@ private:
 
   image_geometry::PinholeCameraModel depth_model_, rgb_model_;
 
+  // Parameters
+  bool fill_upsampling_holes_;
+
   void connectCb();
 
   void imageCb(
@@ -89,12 +95,10 @@ private:
     const Image::ConstSharedPtr & depth_msg,
     const Image::SharedPtr & registered_msg,
     const Eigen::Affine3d & depth_to_rgb);
-
-  rclcpp::Logger logger_ = rclcpp::get_logger("RegisterNode");
 };
 
-RegisterNode::RegisterNode()
-: Node("RegisterNode")
+RegisterNode::RegisterNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("RegisterNode", options)
 {
   rclcpp::Clock::SharedPtr clock = this->get_clock();
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
@@ -102,6 +106,7 @@ RegisterNode::RegisterNode()
 
   // Read parameters
   int queue_size = this->declare_parameter<int>("queue_size", 5);
+  fill_upsampling_holes_ = this->declare_parameter<bool>("fill_upsampling_holes", false);
 
   // Synchronize inputs. Topic subscriptions happen on demand in the connection callback.
   sync_ = std::make_shared<Synchronizer>(
@@ -109,7 +114,10 @@ RegisterNode::RegisterNode()
     sub_depth_image_,
     sub_depth_info_,
     sub_rgb_info_);
-  sync_->registerCallback(std::bind(&RegisterNode::imageCb, this, _1, _2, _3));
+  sync_->registerCallback(
+    std::bind(
+      &RegisterNode::imageCb, this, std::placeholders::_1,
+      std::placeholders::_2, std::placeholders::_3));
 
   // Monitor whether anyone is subscribed to the output
   // TODO(ros2) Implement when SubscriberStatusCallback is available
@@ -165,7 +173,7 @@ void RegisterNode::imageCb(
 
     depth_to_rgb = tf2::transformToEigen(transform);
   } catch (tf2::TransformException & ex) {
-    RCLCPP_ERROR(logger_, "TF2 exception:\n%s", ex.what());
+    RCLCPP_ERROR(get_logger(), "TF2 exception:\n%s", ex.what());
     return;
     /// @todo Can take on order of a minute to register a disconnect callback when we
     /// don't call publish() in this cb. What's going on roscpp?
@@ -181,13 +189,13 @@ void RegisterNode::imageCb(
   registered_msg->width = resolution.width;
   // step and data set in convert(), depend on depth data type
 
-  if (depth_image_msg->encoding == enc::TYPE_16UC1) {
+  if (depth_image_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1) {
     convert<uint16_t>(depth_image_msg, registered_msg, depth_to_rgb);
-  } else if (depth_image_msg->encoding == enc::TYPE_32FC1) {
+  } else if (depth_image_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1) {
     convert<float>(depth_image_msg, registered_msg, depth_to_rgb);
   } else {
     RCLCPP_ERROR(
-      logger_, "Depth image has unsupported encoding [%s]",
+      get_logger(), "Depth image has unsupported encoding [%s]",
       depth_image_msg->encoding.c_str());
     return;
   }
@@ -237,33 +245,75 @@ void RegisterNode::convert(
 
       double depth = DepthTraits<T>::toMeters(raw_depth);
 
-      /// @todo Combine all operations into one matrix multiply on (u,v,d)
-      // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
-      Eigen::Vector4d xyz_depth;
-      xyz_depth << ((u - depth_cx) * depth - depth_Tx) * inv_depth_fx,
-      ((v - depth_cy) * depth - depth_Ty) * inv_depth_fy,
-        depth,
-        1;
+      if (fill_upsampling_holes_ == false) {
+        /// @todo Combine all operations into one matrix multiply on (u,v,d)
+        // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
+        Eigen::Vector4d xyz_depth;
+        xyz_depth << ((u - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
 
-      // Transform to RGB camera frame
-      Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
+        // Transform to RGB camera frame
+        Eigen::Vector4d xyz_rgb = depth_to_rgb * xyz_depth;
 
-      // Project to (u,v) in RGB image
-      double inv_Z = 1.0 / xyz_rgb.z();
-      int u_rgb = (rgb_fx * xyz_rgb.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
-      int v_rgb = (rgb_fy * xyz_rgb.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
+        // Project to (u,v) in RGB image
+        double inv_Z = 1.0 / xyz_rgb.z();
+        int u_rgb = (rgb_fx * xyz_rgb.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb = (rgb_fy * xyz_rgb.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
 
-      if (u_rgb < 0 || u_rgb >= static_cast<int>(registered_msg->width) ||
-        v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height))
-      {
-        continue;
-      }
+        if (u_rgb < 0 || u_rgb >= static_cast<int>(registered_msg->width) ||
+          v_rgb < 0 || v_rgb >= static_cast<int>(registered_msg->height))
+        {
+          continue;
+        }
 
-      T & reg_depth = registered_data[v_rgb * registered_msg->width + u_rgb];
-      T new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
-      // Validity and Z-buffer checks
-      if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
-        reg_depth = new_depth;
+        T & reg_depth = registered_data[v_rgb * registered_msg->width + u_rgb];
+        T new_depth = DepthTraits<T>::fromMeters(xyz_rgb.z());
+        // Validity and Z-buffer checks
+        if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
+          reg_depth = new_depth;
+        }
+      } else {
+        // Reproject (u,v,Z) to (X,Y,Z,1) in depth camera frame
+        Eigen::Vector4d xyz_depth_1, xyz_depth_2;
+        xyz_depth_1 << ((u - 0.5f - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v - 0.5f - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
+        xyz_depth_2 << ((u + 0.5f - depth_cx) * depth - depth_Tx) * inv_depth_fx,
+          ((v + 0.5f - depth_cy) * depth - depth_Ty) * inv_depth_fy,
+          depth,
+          1;
+
+        // Transform to RGB camera frame
+        Eigen::Vector4d xyz_rgb_1 = depth_to_rgb * xyz_depth_1;
+        Eigen::Vector4d xyz_rgb_2 = depth_to_rgb * xyz_depth_2;
+
+        // Project to (u,v) in RGB image
+        double inv_Z = 1.0 / xyz_rgb_1.z();
+        int u_rgb_1 = (rgb_fx * xyz_rgb_1.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb_1 = (rgb_fy * xyz_rgb_1.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
+        inv_Z = 1.0 / xyz_rgb_2.z();
+        int u_rgb_2 = (rgb_fx * xyz_rgb_2.x() + rgb_Tx) * inv_Z + rgb_cx + 0.5;
+        int v_rgb_2 = (rgb_fy * xyz_rgb_2.y() + rgb_Ty) * inv_Z + rgb_cy + 0.5;
+
+        if (u_rgb_1 < 0 || u_rgb_2 >= static_cast<int>(registered_msg->width) ||
+          v_rgb_1 < 0 || v_rgb_2 >= static_cast<int>(registered_msg->height))
+        {
+          continue;
+        }
+
+        for (int nv = v_rgb_1; nv <= v_rgb_2; ++nv) {
+          for (int nu = u_rgb_1; nu <= u_rgb_2; ++nu) {
+            T & reg_depth = registered_data[nv * registered_msg->width + nu];
+            T new_depth = DepthTraits<T>::fromMeters(0.5 * (xyz_rgb_1.z() + xyz_rgb_2.z()));
+            // Validity and Z-buffer checks
+            if (!DepthTraits<T>::valid(reg_depth) || reg_depth > new_depth) {
+              reg_depth = new_depth;
+            }
+          }
+        }
       }
     }
   }
@@ -271,7 +321,7 @@ void RegisterNode::convert(
 
 }  // namespace depth_image_proc
 
-#include "class_loader/register_macro.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
 
 // Register the component with class_loader.
-CLASS_LOADER_REGISTER_CLASS(depth_image_proc::RegisterNode, rclcpp::Node)
+RCLCPP_COMPONENTS_REGISTER_NODE(depth_image_proc::RegisterNode)

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
@@ -312,6 +312,92 @@ TRACEPOINT_EVENT(
   )
 )
 
+// depth_image_proc point_cloud_xyzrgb init callback
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  depth_image_proc_transform_to_pointcloud_cb_init,
+  TP_ARGS(
+    const void *, point_cloud_xyzrgb_node_arg,
+    const void *, point_cloud_xyzrgb_depth_image_msg_arg,
+    const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
+    const void *, point_cloud_xyzrgb_info_msg_arg,
+    uint32_t, image_input_header_nsec_arg,
+    uint32_t, image_input_header_sec_arg),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_rgb_image_msg, point_cloud_xyzrgb_rgb_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
+    ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
+    ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_string(version, tracetools_image_pipeline_VERSION)
+  )
+)
+// depth_image_proc point_cloud_xyzrgb end of callback (after publication)
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  depth_image_proc_transform_to_pointcloud_cb_fini,
+  TP_ARGS(
+    const void *, point_cloud_xyzrgb_node_arg,
+    const void *, point_cloud_xyzrgb_depth_image_msg_arg,
+    const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
+    const void *, point_cloud_xyzrgb_info_msg_arg,
+    uint32_t, image_input_header_nsec_arg,
+    uint32_t, image_input_header_sec_arg),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_rgb_image_msg, point_cloud_xyzrgb_rgb_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
+    ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
+    ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_string(version, tracetools_image_pipeline_VERSION)
+  )
+)
+
+// depth_image_proc point_cloud_xyzrgb init
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  depth_image_proc_transform_to_pointcloud_init,
+  TP_ARGS(
+    const void *, point_cloud_xyzrgb_node_arg,
+    const void *, point_cloud_xyzrgb_depth_image_msg_arg,
+    const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
+    const void *, point_cloud_xyzrgb_info_msg_arg,
+    uint32_t, image_input_header_nsec_arg,
+    uint32_t, image_input_header_sec_arg),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_rgb_image_msg, point_cloud_xyzrgb_rgb_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
+    ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
+    ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_string(version, tracetools_image_pipeline_VERSION)
+  )
+)
+// depth_image_proc point_cloud_xyzrgb end of (after having created the pointcloud)
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  depth_image_proc_transform_to_pointcloud_fini,
+  TP_ARGS(
+    const void *, point_cloud_xyzrgb_node_arg,
+    const void *, point_cloud_xyzrgb_depth_image_msg_arg,
+    const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
+    const void *, point_cloud_xyzrgb_info_msg_arg,
+    uint32_t, image_input_header_nsec_arg,
+    uint32_t, image_input_header_sec_arg),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_rgb_image_msg, point_cloud_xyzrgb_rgb_image_msg_arg)
+    ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
+    ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
+    ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_string(version, tracetools_image_pipeline_VERSION)
+  )
+)
+
 #endif  // _TRACETOOLS_IMAGE_PIPELINE__TP_CALL_H_
 
 #include <lttng/tracepoint-event.h>

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
@@ -378,7 +378,10 @@ TRACEPOINT_EVENT(
     const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
     const void *, point_cloud_xyzrgb_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, point_cloud_xyzrgb_depth_msg_size_arg,
+    size_t, point_cloud_xyzrgb_rgb_msg_size_arg,
+    size_t, point_cloud_xyzrgb_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
     ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
@@ -386,6 +389,9 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_depth_msg_size, point_cloud_xyzrgb_depth_msg_size_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_rgb_msg_size, point_cloud_xyzrgb_rgb_msg_size_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_info_msg_size, point_cloud_xyzrgb_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -399,7 +405,10 @@ TRACEPOINT_EVENT(
     const void *, point_cloud_xyzrgb_rgb_image_msg_arg,
     const void *, point_cloud_xyzrgb_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, point_cloud_xyzrgb_depth_msg_size_arg,
+    size_t, point_cloud_xyzrgb_rgb_msg_size_arg,
+    size_t, point_cloud_xyzrgb_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, point_cloud_xyzrgb_node, point_cloud_xyzrgb_node_arg)
     ctf_integer_hex(const void *, point_cloud_xyzrgb_depth_image_msg, point_cloud_xyzrgb_depth_image_msg_arg)
@@ -407,6 +416,9 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, point_cloud_xyzrgb_info_msg, point_cloud_xyzrgb_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_depth_msg_size, point_cloud_xyzrgb_depth_msg_size_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_rgb_msg_size, point_cloud_xyzrgb_rgb_msg_size_arg)
+    ctf_integer(uint32_t, point_cloud_xyzrgb_info_msg_size, point_cloud_xyzrgb_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
@@ -339,6 +339,94 @@ DECLARE_TRACEPOINT(
   uint32_t image_input_header_nsec_arg,
   uint32_t image_input_header_sec_arg)
 
+/// `depth_image_proc_transform_to_pointcloud_cb_init`
+/**
+ * Tracepoint while initiating the RGBd to pointcloud operation
+ *
+ * Notes the `tracetools_image_pipeline` version automatically.
+ *
+ * \param[in] point_cloud_xyzrgb_node rclcpp::node::Node subject to the callback
+ * \param[in] point_cloud_xyzrgb_depth_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_rgb_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
+ * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ */
+DECLARE_TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_cb_init,
+  const void * point_cloud_xyzrgb_node,
+  const void * point_cloud_xyzrgb_depth_image_msg,
+  const void * point_cloud_xyzrgb_rgb_image_msg,
+  const void * point_cloud_xyzrgb_info_msg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+
+/// `depth_image_proc_transform_to_pointcloud_cb_fini`
+/**
+ * Tracepoint while initiating the RGBd to pointcloud operation
+ *
+ * Notes the `tracetools_image_pipeline` version automatically.
+ *
+ * \param[in] point_cloud_xyzrgb_node rclcpp::node::Node subject to the callback
+ * \param[in] point_cloud_xyzrgb_depth_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_rgb_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
+ * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ */
+DECLARE_TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_cb_fini,
+  const void * point_cloud_xyzrgb_node,
+  const void * point_cloud_xyzrgb_depth_image_msg,
+  const void * point_cloud_xyzrgb_rgb_image_msg,
+  const void * point_cloud_xyzrgb_info_msg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+
+/// `depth_image_proc_transform_to_pointcloud_init`
+/**
+ * Tracepoint while initiating the RGBd to pointcloud operation
+ *
+ * Notes the `tracetools_image_pipeline` version automatically.
+ *
+ * \param[in] point_cloud_xyzrgb_node rclcpp::node::Node subject to the callback
+ * \param[in] point_cloud_xyzrgb_depth_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_rgb_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
+ * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ */
+DECLARE_TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_init,
+  const void * point_cloud_xyzrgb_node,
+  const void * point_cloud_xyzrgb_depth_image_msg,
+  const void * point_cloud_xyzrgb_rgb_image_msg,
+  const void * point_cloud_xyzrgb_info_msg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+
+/// `depth_image_proc_transform_to_pointcloud_fini`
+/**
+ * Tracepoint while initiating the RGBd to pointcloud operation
+ *
+ * Notes the `tracetools_image_pipeline` version automatically.
+ *
+ * \param[in] point_cloud_xyzrgb_node rclcpp::node::Node subject to the callback
+ * \param[in] point_cloud_xyzrgb_depth_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_rgb_image_msg image ROS message stored as sensor_msgs::msg::Image::ConstSharedPtr
+ * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
+ * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ */
+DECLARE_TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_fini,
+  const void * point_cloud_xyzrgb_node,
+  const void * point_cloud_xyzrgb_depth_image_msg,
+  const void * point_cloud_xyzrgb_rgb_image_msg,
+  const void * point_cloud_xyzrgb_info_msg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+
 #ifdef __cplusplus
 }
 #endif

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
@@ -407,6 +407,9 @@ DECLARE_TRACEPOINT(
  * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] point_cloud_xyzrgb_depth_msg_size size of image ROS message stored as bytes
+ * \param[in] point_cloud_xyzrgb_rgb_msg_size size of image ROS message stored as bytes
+ * \param[in] point_cloud_xyzrgb_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   depth_image_proc_transform_to_pointcloud_cb_init,
@@ -415,7 +418,10 @@ DECLARE_TRACEPOINT(
   const void * point_cloud_xyzrgb_rgb_image_msg,
   const void * point_cloud_xyzrgb_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t point_cloud_xyzrgb_depth_msg_size,
+  size_t point_cloud_xyzrgb_rgb_msg_size,
+  size_t point_cloud_xyzrgb_info_msg_size)
 
 /// `depth_image_proc_transform_to_pointcloud_cb_fini`
 /**
@@ -429,6 +435,9 @@ DECLARE_TRACEPOINT(
  * \param[in] point_cloud_xyzrgb_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] point_cloud_xyzrgb_depth_msg_size size of image ROS message stored as bytes
+ * \param[in] point_cloud_xyzrgb_rgb_msg_size size of image ROS message stored as bytes
+ * \param[in] point_cloud_xyzrgb_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   depth_image_proc_transform_to_pointcloud_cb_fini,
@@ -437,7 +446,10 @@ DECLARE_TRACEPOINT(
   const void * point_cloud_xyzrgb_rgb_image_msg,
   const void * point_cloud_xyzrgb_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t point_cloud_xyzrgb_depth_msg_size,
+  size_t point_cloud_xyzrgb_rgb_msg_size,
+  size_t point_cloud_xyzrgb_info_msg_size)
 
 /// `depth_image_proc_transform_to_pointcloud_init`
 /**

--- a/tracetools_image_pipeline/src/tracetools.c
+++ b/tracetools_image_pipeline/src/tracetools.c
@@ -344,7 +344,10 @@ void TRACEPOINT(
   const void * point_cloud_xyzrgb_rgb_image_msg_arg,
   const void * point_cloud_xyzrgb_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t point_cloud_xyzrgb_depth_msg_size_arg,
+  size_t point_cloud_xyzrgb_rgb_msg_size_arg,
+  size_t point_cloud_xyzrgb_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     depth_image_proc_transform_to_pointcloud_cb_init,
@@ -353,7 +356,10 @@ void TRACEPOINT(
     point_cloud_xyzrgb_rgb_image_msg_arg,
     point_cloud_xyzrgb_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    point_cloud_xyzrgb_depth_msg_size_arg,
+    point_cloud_xyzrgb_rgb_msg_size_arg,
+    point_cloud_xyzrgb_info_msg_size_arg);
 }
 
 void TRACEPOINT(
@@ -363,7 +369,10 @@ void TRACEPOINT(
   const void * point_cloud_xyzrgb_rgb_image_msg_arg,
   const void * point_cloud_xyzrgb_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t point_cloud_xyzrgb_depth_msg_size_arg,
+  size_t point_cloud_xyzrgb_rgb_msg_size_arg,
+  size_t point_cloud_xyzrgb_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     depth_image_proc_transform_to_pointcloud_cb_fini,
@@ -372,7 +381,10 @@ void TRACEPOINT(
     point_cloud_xyzrgb_rgb_image_msg_arg,
     point_cloud_xyzrgb_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    point_cloud_xyzrgb_depth_msg_size_arg,
+    point_cloud_xyzrgb_rgb_msg_size_arg,
+    point_cloud_xyzrgb_info_msg_size_arg);
 }
 
 void TRACEPOINT(

--- a/tracetools_image_pipeline/src/tracetools.c
+++ b/tracetools_image_pipeline/src/tracetools.c
@@ -278,6 +278,83 @@ void TRACEPOINT(
     image_input_header_sec_arg);
 }
 
+// point_cloud_xyzrgb
+void TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_cb_init,
+  const void * point_cloud_xyzrgb_node_arg,
+  const void * point_cloud_xyzrgb_depth_image_msg_arg,
+  const void * point_cloud_xyzrgb_rgb_image_msg_arg,
+  const void * point_cloud_xyzrgb_info_msg_arg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+{
+  CONDITIONAL_TP(
+    depth_image_proc_transform_to_pointcloud_cb_init,
+    point_cloud_xyzrgb_node_arg,
+    point_cloud_xyzrgb_depth_image_msg_arg,
+    point_cloud_xyzrgb_rgb_image_msg_arg,
+    point_cloud_xyzrgb_info_msg_arg,
+    image_input_header_nsec_arg,
+    image_input_header_sec_arg);
+}
+
+void TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_cb_fini,
+  const void * point_cloud_xyzrgb_node_arg,
+  const void * point_cloud_xyzrgb_depth_image_msg_arg,
+  const void * point_cloud_xyzrgb_rgb_image_msg_arg,
+  const void * point_cloud_xyzrgb_info_msg_arg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+{
+  CONDITIONAL_TP(
+    depth_image_proc_transform_to_pointcloud_cb_fini,
+    point_cloud_xyzrgb_node_arg,
+    point_cloud_xyzrgb_depth_image_msg_arg,
+    point_cloud_xyzrgb_rgb_image_msg_arg,
+    point_cloud_xyzrgb_info_msg_arg,
+    image_input_header_nsec_arg,
+    image_input_header_sec_arg);
+}
+
+void TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_init,
+  const void * point_cloud_xyzrgb_node_arg,
+  const void * point_cloud_xyzrgb_depth_image_msg_arg,
+  const void * point_cloud_xyzrgb_rgb_image_msg_arg,
+  const void * point_cloud_xyzrgb_info_msg_arg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+{
+  CONDITIONAL_TP(
+    depth_image_proc_transform_to_pointcloud_init,
+    point_cloud_xyzrgb_node_arg,
+    point_cloud_xyzrgb_depth_image_msg_arg,
+    point_cloud_xyzrgb_rgb_image_msg_arg,
+    point_cloud_xyzrgb_info_msg_arg,
+    image_input_header_nsec_arg,
+    image_input_header_sec_arg);
+}
+
+void TRACEPOINT(
+  depth_image_proc_transform_to_pointcloud_fini,
+  const void * point_cloud_xyzrgb_node_arg,
+  const void * point_cloud_xyzrgb_depth_image_msg_arg,
+  const void * point_cloud_xyzrgb_rgb_image_msg_arg,
+  const void * point_cloud_xyzrgb_info_msg_arg,
+  uint32_t image_input_header_nsec_arg,
+  uint32_t image_input_header_sec_arg)
+{
+  CONDITIONAL_TP(
+    depth_image_proc_transform_to_pointcloud_fini,
+    point_cloud_xyzrgb_node_arg,
+    point_cloud_xyzrgb_depth_image_msg_arg,
+    point_cloud_xyzrgb_rgb_image_msg_arg,
+    point_cloud_xyzrgb_info_msg_arg,
+    image_input_header_nsec_arg,
+    image_input_header_sec_arg);
+}
+
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #else


### PR DESCRIPTION
The goal of this PR is to add tracepoints in the `/benchmark/depth_image_to_pointcloud_node` node of the [`a4_depth_image_proc`](https://github.com/robotperf/benchmarks/pull/18) benchmark so they can be used at https://github.com/robotperf/benchmarks/pull/34.

Steps:
- [x] Merge `depth_image_proc` from [`ros-perception/image_proc`](https://github.com/ros-perception/image_pipeline) (see [problem](https://github.com/robotperf/benchmarks/pull/34#issuecomment-1559628974)).
- [x] Define tracepoints in [`tracetools_image_pipeline`](https://github.com/ros-acceleration/image_pipeline/tree/ros2/tracetools_image_pipeline).
- [x] Use tracepoints in the `imageCb` function of [`PointCloudXyzrgbNode`](https://github.com/ros-acceleration/image_pipeline/blob/ros2/depth_image_proc/src/point_cloud_xyzrgb.cpp#L130).