### PR TITLE
Size tracepoint

### DIFF
--- a/image_proc/include/image_proc/rectify.hpp
+++ b/image_proc/include/image_proc/rectify.hpp
@@ -1,3 +1,7 @@
+/* Modification Copyright (c) 2023, Acceleration Robotics®
+   Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   Based on:
+*/
 // Copyright 2008, 2019 Willow Garage, Inc., Andreas Klintberg, Joshua Whitley
 // All rights reserved.
 //
@@ -64,6 +68,9 @@ private:
   image_geometry::PinholeCameraModel model_;
 
   void subscribeToCamera();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_fpga.hpp
+++ b/image_proc/include/image_proc/rectify_fpga.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -89,6 +92,8 @@ private:
   image_geometry::PinholeCameraModelFPGA model_;
 
   void subscribeToCamera();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_fpga_streamlined.hpp
+++ b/image_proc/include/image_proc/rectify_fpga_streamlined.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -88,6 +91,8 @@ private:
   image_geometry::PinholeCameraModelFPGAStreamlined model_;
 
   void subscribeToCamera();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_fpga_streamlined_xrt.hpp
+++ b/image_proc/include/image_proc/rectify_fpga_streamlined_xrt.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -96,6 +99,10 @@ private:
   image_geometry::PinholeCameraModelFPGAStreamlinedXRT model_;
 
   void subscribeToCamera();
+
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+  
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_resize_fpga_integrated.hpp
+++ b/image_proc/include/image_proc/rectify_resize_fpga_integrated.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -97,6 +100,8 @@ private:
   image_geometry::PinholeCameraModelFPGAIntegrated model_;
 
   void subscribeToCamera();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_resize_fpga_integrated_xrt.hpp
+++ b/image_proc/include/image_proc/rectify_resize_fpga_integrated_xrt.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -101,6 +104,9 @@ private:
   image_geometry::PinholeCameraModelFPGAIntegratedXRT model_;
 
   void subscribeToCamera();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg);

--- a/image_proc/include/image_proc/rectify_resize_fpga_streamlined.hpp
+++ b/image_proc/include/image_proc/rectify_resize_fpga_streamlined.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -116,6 +119,9 @@ private:
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg,
     bool gray);
+    
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
 
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,

--- a/image_proc/include/image_proc/rectify_resize_fpga_streamlined_xrt.hpp
+++ b/image_proc/include/image_proc/rectify_resize_fpga_streamlined_xrt.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -116,6 +119,9 @@ private:
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg,
     bool gray);
+  
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
 
   void imageCb(
     const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,

--- a/image_proc/include/image_proc/resize.hpp
+++ b/image_proc/include/image_proc/resize.hpp
@@ -1,3 +1,7 @@
+/*  Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
+*/
 // Copyright 2008, 2019 Willow Garage, Inc., Andreas Klintberg, Joshua Whitley
 // All rights reserved.
 //
@@ -67,6 +71,8 @@ protected:
   std::mutex connect_mutex_;
 
   void connectCb();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
 
   void imageCb(
     sensor_msgs::msg::Image::ConstSharedPtr image_msg,

--- a/image_proc/include/image_proc/resize_fpga.hpp
+++ b/image_proc/include/image_proc/resize_fpga.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -63,6 +66,9 @@ protected:
   std::mutex connect_mutex_;
 
   void connectCb();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
 
   void imageCb(
     sensor_msgs::msg::Image::ConstSharedPtr image_msg,

--- a/image_proc/include/image_proc/resize_fpga_streamlined.hpp
+++ b/image_proc/include/image_proc/resize_fpga_streamlined.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -65,6 +68,9 @@ protected:
   std::mutex connect_mutex_;
 
   void connectCb();
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
 
   void imageCb(
     sensor_msgs::msg::Image::ConstSharedPtr image_msg,

--- a/image_proc/include/image_proc/resize_fpga_streamlined_xrt.hpp
+++ b/image_proc/include/image_proc/resize_fpga_streamlined_xrt.hpp
@@ -1,4 +1,7 @@
 /*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -69,6 +72,10 @@ protected:
   std::mutex connect_mutex_;
 
   void connectCb();
+
+  size_t get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg);
+  size_t get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg);
+
 
   void imageCb(
     sensor_msgs::msg::Image::ConstSharedPtr image_msg,

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -1,27 +1,7 @@
-/*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
+/* Modification Copyright (c) 2023, Acceleration Robotics®
+   Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   Based on:
 */
-
 // Copyright 2008, 2019 Willow Garage, Inc., Andreas Klintberg, Joshua Whitley
 // All rights reserved.
 //
@@ -99,22 +79,29 @@ void RectifyNode::subscribeToCamera()
   // }
 }
 
-void RectifyNode::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyNode::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyNode::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
+void RectifyNode::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
   
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -123,8 +110,8 @@ void RectifyNode::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -134,8 +121,8 @@ void RectifyNode::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -151,8 +138,8 @@ void RectifyNode::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -176,8 +163,8 @@ void RectifyNode::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -210,16 +197,6 @@ void RectifyNode::imageCb(
     cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   pub_rect_.publish(rect_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_rect;
-  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
-  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
-  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.size();
-  
-  info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.size();
 
   TRACEPOINT(
     image_proc_rectify_cb_fini,
@@ -228,8 +205,8 @@ void RectifyNode::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    rect_msg_size,
-    info_msg_size);
+    get_msg_size(rect_msg),
+    get_msg_size(info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -195,9 +195,7 @@ void RectifyNode::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
   model_.rectifyImage(image, rect, interpolation);
   TRACEPOINT(
     image_proc_rectify_fini,
@@ -205,23 +203,32 @@ void RectifyNode::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   // Allocate new rectified image message
   sensor_msgs::msg::Image::SharedPtr rect_msg =
     cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   pub_rect_.publish(rect_msg);
 
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_rect;
+  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
+  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
+  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
+  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  
+  info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
+    static_cast<const void *>(&(*rect_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
+    rect_msg_size,
     info_msg_size);
 }
 

--- a/image_proc/src/rectify.cpp
+++ b/image_proc/src/rectify.cpp
@@ -108,13 +108,13 @@ void RectifyNode::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -215,11 +215,11 @@ void RectifyNode::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  size_t rect_msg_size = serialized_data_rect.size();
   
   info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  info_msg_size = serialized_data_info.size();
 
   TRACEPOINT(
     image_proc_rectify_cb_fini,

--- a/image_proc/src/rectify_fpga.cpp
+++ b/image_proc/src/rectify_fpga.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_fpga.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -381,6 +406,19 @@ void RectifyNodeFPGA::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -388,7 +426,9 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -397,7 +437,9 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -412,7 +454,9 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -435,7 +479,9 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -456,7 +502,9 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
   // model_.rectifyImage(image, rect, interpolation);  // CPU computation
   // model_.rectifyImageFPGA_debug(image, rect, gray);  // CPU and FPGA debug computations
   model_.rectifyImageFPGA(image, rect, gray);  // FPGA computation
@@ -466,7 +514,9 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // Allocate new rectified image message
   sensor_msgs::msg::Image::SharedPtr rect_msg =
@@ -479,7 +529,9 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_fpga.cpp
+++ b/image_proc/src/rectify_fpga.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -402,23 +381,29 @@ void RectifyNodeFPGA::subscribeToCamera()
   // }
 }
 
-void RectifyNodeFPGA::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyNodeFPGA::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyNodeFPGA::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
-  
+  return info_msg_size;
+}
+
+void RectifyNodeFPGA::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -427,8 +412,8 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -438,8 +423,8 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -455,8 +440,8 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -480,8 +465,8 @@ void RectifyNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -519,17 +504,6 @@ void RectifyNodeFPGA::imageCb(
     cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   pub_rect_.publish(rect_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_rect;
-  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
-  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
-  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.size();
-  
-  info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.size();
-  
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
@@ -537,8 +511,8 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    rect_msg_size,
-    info_msg_size);
+    get_msg_size(rect_msg),
+    get_msg_size(info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_fpga.cpp
+++ b/image_proc/src/rectify_fpga.cpp
@@ -502,9 +502,7 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
   // model_.rectifyImage(image, rect, interpolation);  // CPU computation
   // model_.rectifyImageFPGA_debug(image, rect, gray);  // CPU and FPGA debug computations
   model_.rectifyImageFPGA(image, rect, gray);  // FPGA computation
@@ -514,23 +512,32 @@ void RectifyNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   // Allocate new rectified image message
   sensor_msgs::msg::Image::SharedPtr rect_msg =
     cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   pub_rect_.publish(rect_msg);
 
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_rect;
+  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
+  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
+  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
+  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  
+  info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
+    static_cast<const void *>(&(*rect_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
+    rect_msg_size,
     info_msg_size);
 }
 

--- a/image_proc/src/rectify_fpga.cpp
+++ b/image_proc/src/rectify_fpga.cpp
@@ -411,13 +411,13 @@ void RectifyNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
 
   TRACEPOINT(
@@ -524,11 +524,11 @@ void RectifyNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  size_t rect_msg_size = serialized_data_rect.size();
   
   info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  info_msg_size = serialized_data_info.size();
   
   TRACEPOINT(
     image_proc_rectify_cb_fini,

--- a/image_proc/src/rectify_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_fpga_streamlined.cpp
@@ -258,13 +258,13 @@ void RectifyNodeFPGAStreamlined::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   // std::cout << "RectifyNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
@@ -369,11 +369,11 @@ void RectifyNodeFPGAStreamlined::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  size_t rect_msg_size = serialized_data_rect.size();
   
   info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  info_msg_size = serialized_data_info.size();
 
 
   TRACEPOINT(

--- a/image_proc/src/rectify_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_fpga_streamlined.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_fpga_streamlined.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -228,7 +253,19 @@ void RectifyNodeFPGAStreamlined::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
-
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   // std::cout << "RectifyNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -236,7 +273,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -245,7 +284,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -260,7 +301,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -283,7 +326,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -304,7 +349,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
   model_.rectifyImageFPGA(image, rect, gray);  // FPGA computation
   TRACEPOINT(
     image_proc_rectify_fini,
@@ -312,7 +359,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // // Allocate new rectified image message
   // sensor_msgs::msg::Image::SharedPtr rect_msg =
@@ -325,7 +374,9 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_fpga_streamlined.cpp
@@ -349,9 +349,7 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
   model_.rectifyImageFPGA(image, rect, gray);  // FPGA computation
   TRACEPOINT(
     image_proc_rectify_fini,
@@ -359,23 +357,33 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
-  // // Allocate new rectified image message
-  // sensor_msgs::msg::Image::SharedPtr rect_msg =
-  //   cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
+  // Allocate new rectified image message
+  sensor_msgs::msg::Image::SharedPtr rect_msg =
+    cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   // pub_rect_.publish(rect_msg);
+
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_rect;
+  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
+  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
+  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
+  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  
+  info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+
 
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
+    static_cast<const void *>(&(*rect_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
+    rect_msg_size,
     info_msg_size);
 }
 

--- a/image_proc/src/rectify_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_fpga_streamlined.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -249,22 +228,29 @@ void RectifyNodeFPGAStreamlined::subscribeToCamera()
   // }
 }
 
-void RectifyNodeFPGAStreamlined::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyNodeFPGAStreamlined::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyNodeFPGAStreamlined::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
+void RectifyNodeFPGAStreamlined::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
   
   // std::cout << "RectifyNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
@@ -274,8 +260,8 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -285,8 +271,8 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -302,8 +288,8 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -327,8 +313,8 @@ void RectifyNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -364,17 +350,6 @@ void RectifyNodeFPGAStreamlined::imageCb(
     cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   // pub_rect_.publish(rect_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_rect;
-  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
-  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
-  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.size();
-  
-  info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.size();
-
 
   TRACEPOINT(
     image_proc_rectify_cb_fini,
@@ -383,8 +358,8 @@ void RectifyNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    rect_msg_size,
-    info_msg_size);
+    get_msg_size(rect_msg),
+    get_msg_size(info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_fpga_streamlined_xrt.cpp
@@ -243,13 +243,13 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   // std::cout << "RectifyNodeFPGAStreamlinedXRT::imageCb XRT" << std::endl;
   TRACEPOINT(
@@ -355,11 +355,11 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect_img);
-  size_t rect_image_msg_size = serialized_data_rect_img.get_rcl_serialized_message().buffer_length;
+  size_t rect_image_msg_size = serialized_data_rect_img.size();
   
   info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  info_msg_size = serialized_data_info.size();
 
   TRACEPOINT(
     image_proc_rectify_cb_fini,

--- a/image_proc/src/rectify_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_fpga_streamlined_xrt.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -101,6 +80,7 @@ PinholeCameraModelFPGAStreamlinedXRT::PinholeCameraModelFPGAStreamlinedXRT()
   uuid = device.load_xclbin("/lib/firmware/xilinx/image_proc_streamlined/image_proc_streamlined.xclbin");
   krnl_rectify = xrt::kernel(device, uuid, "rectify_accel_streamlined");
 }
+
 
 void PinholeCameraModelFPGAStreamlinedXRT::rectifyImageFPGA(const cv::Mat& raw, cv::Mat& rectified, bool gray) const
 {
@@ -214,6 +194,25 @@ RectifyNodeFPGAStreamlinedXRT::RectifyNodeFPGAStreamlinedXRT(const rclcpp::NodeO
   subscribeToCamera();
 }
 
+size_t RectifyNodeFPGAStreamlinedXRT::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.size();
+  return image_msg_size;
+}
+
+size_t RectifyNodeFPGAStreamlinedXRT::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
 // Handles (un)subscribing when clients (un)subscribe
 void RectifyNodeFPGAStreamlinedXRT::subscribeToCamera()
 {
@@ -238,18 +237,6 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
-  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
-  image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.size();
-  
-  rclcpp::SerializedMessage serialized_data_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
-  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.size();
   
   // std::cout << "RectifyNodeFPGAStreamlinedXRT::imageCb XRT" << std::endl;
   TRACEPOINT(
@@ -259,8 +246,8 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -270,8 +257,8 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -287,8 +274,8 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -312,8 +299,8 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
 
     return;
   }
@@ -350,17 +337,6 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
      cv_bridge::CvImage(image_msg->header, image_msg->encoding, rect).toImageMsg();
   // pub_rect_.publish(rect_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_rect_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
-  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
-  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect_img);
-  size_t rect_image_msg_size = serialized_data_rect_img.size();
-  
-  info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  info_msg_size = serialized_data_info.size();
-
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
@@ -368,8 +344,8 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*info_msg))
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    rect_image_msg_size,
-    info_msg_size);
+    get_msg_size(rect_msg),
+    get_msg_size(info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_fpga_streamlined_xrt.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_fpga_streamlined_xrt.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -213,7 +238,19 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
-
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   // std::cout << "RectifyNodeFPGAStreamlinedXRT::imageCb XRT" << std::endl;
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -221,7 +258,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_rect_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -230,7 +269,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -245,7 +286,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -268,7 +311,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
 
     return;
   }
@@ -290,7 +335,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg))
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
   model_.rectifyImageFPGA(image, rect, gray);  // FPGA computation
   TRACEPOINT(
     image_proc_rectify_fini,
@@ -298,7 +345,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg))
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // // Allocate new rectified image message
   // sensor_msgs::msg::Image::SharedPtr rect_msg =
@@ -311,7 +360,9 @@ void RectifyNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg))
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_integrated.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated.cpp
@@ -127,19 +127,7 @@ void PinholeCameraModelFPGAIntegrated::rectifyResizeImageFPGA(
   sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg,
   bool gray) const
 {
-    //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
-  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
-  image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
-  
-  rclcpp::SerializedMessage serialized_data_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
-  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
-  
+
   // Rectify and resize
   TRACEPOINT(
     image_proc_rectify_init,
@@ -147,9 +135,7 @@ void PinholeCameraModelFPGAIntegrated::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   assert(initialized());
 
@@ -266,9 +252,7 @@ void PinholeCameraModelFPGAIntegrated::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 }
 
 }  // namespace image_geometry
@@ -488,15 +472,29 @@ void RectifyResizeNodeFPGA::imageCb(
   }
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
+  
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_rect;
+  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
+  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
+  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
+  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_dst_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
+  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
+  info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
+  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
-    static_cast<const void *>(&(*info_msg)),
+    static_cast<const void *>(&(*output_image.toImageMsg())),
+    static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    rect_msg_size,
+    dst_info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_integrated.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated.cpp
@@ -310,13 +310,13 @@ void RectifyResizeNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -478,13 +478,13 @@ void RectifyResizeNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  size_t rect_msg_size = serialized_data_rect.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
   
   TRACEPOINT(
     image_proc_rectify_cb_fini,

--- a/image_proc/src/rectify_resize_fpga_integrated.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -301,23 +280,31 @@ void RectifyResizeNodeFPGA::subscribeToCamera()
   // }
 }
 
-void RectifyResizeNodeFPGA::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyResizeNodeFPGA::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyResizeNodeFPGA::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
 
+
+void RectifyResizeNodeFPGA::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
+  
   TRACEPOINT(
     image_proc_rectify_cb_init,
     static_cast<const void *>(this),
@@ -325,8 +312,8 @@ void RectifyResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -336,8 +323,8 @@ void RectifyResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -353,8 +340,8 @@ void RectifyResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -378,8 +365,8 @@ void RectifyResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -398,8 +385,8 @@ void RectifyResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -473,19 +460,7 @@ void RectifyResizeNodeFPGA::imageCb(
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
   
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_rect;
-  rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
-  const void* rect_image_ptr = reinterpret_cast<const void*>(rect_msg.get());
-  rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.size();
-  
-  rclcpp::SerializedMessage serialized_data_dst_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
-  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
-  info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.size();
-  
+
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
@@ -493,8 +468,8 @@ void RectifyResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    rect_msg_size,
-    dst_info_msg_size);
+    get_msg_size(output_image.toImageMsg()),
+    get_msg_size(dst_info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
@@ -302,13 +302,13 @@ void RectifyResizeNodeFPGAXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -471,13 +471,13 @@ void RectifyResizeNodeFPGAXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
   const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
-  size_t output_image_msg_size = serialized_data_output_img.get_rcl_serialized_message().buffer_length;
+  size_t output_image_msg_size = serialized_data_output_img.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
   
   
   

--- a/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_resize_fpga_integrated_xrt.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -86,6 +111,19 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
   sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg,
   bool gray) const
 {
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   // Rectify and resize
   TRACEPOINT(
     image_proc_rectify_init,
@@ -93,7 +131,9 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   assert(initialized());
 
@@ -218,7 +258,9 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
 }
 }  // namespace image_geometry
@@ -271,14 +313,28 @@ void RectifyResizeNodeFPGAXRT::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
-
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   TRACEPOINT(
     image_proc_rectify_cb_init,
     static_cast<const void *>(this),
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -287,7 +343,9 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -302,7 +360,9 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -325,7 +385,9 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -343,7 +405,9 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -423,7 +487,9 @@ void RectifyResizeNodeFPGAXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
@@ -111,19 +111,7 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
   sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg,
   bool gray) const
 {
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
-  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
-  image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
-  
-  rclcpp::SerializedMessage serialized_data_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
-  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
-  info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
-  
+    
   // Rectify and resize
   TRACEPOINT(
     image_proc_rectify_init,
@@ -131,9 +119,7 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   assert(initialized());
 
@@ -258,9 +244,7 @@ void PinholeCameraModelFPGAIntegratedXRT::rectifyResizeImageFPGA(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
 }
 }  // namespace image_geometry
@@ -481,15 +465,31 @@ void RectifyResizeNodeFPGAXRT::imageCb(
   }
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
+  
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_output_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
+  const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
+  output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
+  size_t output_image_msg_size = serialized_data_output_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_dst_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
+  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
+  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
+  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  
+  
+  
   TRACEPOINT(
     image_proc_rectify_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
-    static_cast<const void *>(&(*info_msg)),
+    static_cast<const void *>(&(*output_image.toImageMsg())),
+    static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    output_image_msg_size,
+    dst_info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_integrated_xrt.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -293,22 +272,29 @@ void RectifyResizeNodeFPGAXRT::subscribeToCamera()
   // }
 }
 
-void RectifyResizeNodeFPGAXRT::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyResizeNodeFPGAXRT::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyResizeNodeFPGAXRT::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
+void RectifyResizeNodeFPGAXRT::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
   
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -317,8 +303,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -328,8 +314,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -345,8 +331,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -370,8 +356,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -390,8 +376,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -466,19 +452,6 @@ void RectifyResizeNodeFPGAXRT::imageCb(
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
   
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_output_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
-  const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
-  output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
-  size_t output_image_msg_size = serialized_data_output_img.size();
-  
-  rclcpp::SerializedMessage serialized_data_dst_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
-  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
-  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.size();
-  
   
   
   TRACEPOINT(
@@ -488,8 +461,8 @@ void RectifyResizeNodeFPGAXRT::imageCb(
     static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    output_image_msg_size,
-    dst_info_msg_size);
+    get_msg_size(output_image.toImageMsg()),
+    get_msg_size(dst_info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_resize_fpga_streamlined.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_resize_fpga_streamlined.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -409,6 +434,19 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
+    //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -416,7 +454,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -425,7 +465,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -440,7 +482,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -463,7 +507,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -484,7 +530,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
   model_.rectifyImageFPGA(image, rect, gray);  // rectify FPGA computation
 
   // Resize
@@ -492,13 +540,17 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
   //   image_proc_resize_init,
   //   static_cast<const void *>(this),
   //   static_cast<const void *>(&(*image_msg)),
-  //   static_cast<const void *>(&(*info_msg)));
+  //   static_cast<const void *>(&(*info_msg)),
+  //   image_msg_size,
+  //   info_msg_size);
   resizeImageFPGA(image_msg, info_msg, gray);  // resize FPGA computation
   // TRACEPOINT(
   //   image_proc_resize_fini,
   //   static_cast<const void *>(this),
   //   static_cast<const void *>(&(*image_msg)),
-  //   static_cast<const void *>(&(*info_msg)));
+  //   static_cast<const void *>(&(*info_msg)),
+  //   image_msg_size,
+  //   info_msg_size);
 
   TRACEPOINT(
     image_proc_rectify_fini,
@@ -506,7 +558,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // Wrap it
   TRACEPOINT(
@@ -515,7 +569,9 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_streamlined.cpp
+++ b/image_proc/src/rectify_resize_fpga_streamlined.cpp
@@ -448,13 +448,13 @@ void RectifyResizeNodeFPGAStreamlined::resizeImageFPGA(
   rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
   const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
-  size_t output_image_msg_size = serialized_data_output_img.get_rcl_serialized_message().buffer_length;
+  size_t output_image_msg_size = serialized_data_output_img.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
   
   // Wrap it
   TRACEPOINT(
@@ -477,13 +477,13 @@ void RectifyResizeNodeFPGAStreamlined::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
 
   TRACEPOINT(

--- a/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -271,23 +250,30 @@ void RectifyResizeNodeFPGAStreamlinedXRT::subscribeToCamera()
   // }
 }
 
-void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
-  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
-{
+size_t RectifyResizeNodeFPGAStreamlinedXRT::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t RectifyResizeNodeFPGAStreamlinedXRT::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
 
+void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
+  const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
+{
+  
   TRACEPOINT(
     image_proc_rectify_cb_init,
     static_cast<const void *>(this),
@@ -295,8 +281,8 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -306,8 +292,8 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -323,8 +309,8 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -348,8 +334,8 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -495,19 +481,6 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
   }
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_output_img;
-  rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
-  const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
-  output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
-  size_t output_msg_size = serialized_data_output_img.size();
-  
-  rclcpp::SerializedMessage serialized_data_dst_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
-  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
-  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.size();
-  
   // Wrap it
   TRACEPOINT(
     image_proc_rectify_cb_fini,
@@ -516,8 +489,8 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    output_msg_size,
-    dst_info_msg_size);
+    get_msg_size(output_image.toImageMsg()),
+    get_msg_size(dst_info_msg));
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -34,6 +58,7 @@
 
 #include "image_proc/rectify_resize_fpga_streamlined_xrt.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_geometry
 {
@@ -250,6 +275,18 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
   const sensor_msgs::msg::Image::ConstSharedPtr & image_msg,
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info_msg)
 {
+    //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -257,7 +294,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -266,7 +305,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -281,7 +322,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -304,7 +347,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -324,7 +369,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // // Rectify
   // model_.rectifyImageFPGA(image, rect, gray);  // rectify FPGA computation
@@ -425,7 +472,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   // Set the output image
   cv_bridge::CvImage output_image;
@@ -457,7 +506,9 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/rectify_resize_fpga_streamlined_xrt.cpp
@@ -280,13 +280,13 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
 
   TRACEPOINT(
     image_proc_rectify_cb_init,
@@ -500,13 +500,13 @@ void RectifyResizeNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> output_image_serialization;
   const void* output_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   output_image_serialization.serialize_message(output_image_ptr, &serialized_data_output_img);
-  size_t output_msg_size = serialized_data_output_img.get_rcl_serialized_message().buffer_length;
+  size_t output_msg_size = serialized_data_output_img.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
   
   // Wrap it
   TRACEPOINT(

--- a/image_proc/src/resize.cpp
+++ b/image_proc/src/resize.cpp
@@ -102,13 +102,13 @@ void ResizeNode::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -220,13 +220,13 @@ void ResizeNode::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> rect_image_serialization;
   const void* rect_image_ptr = reinterpret_cast<const void*>(cv_ptr->toImageMsg().get());
   rect_image_serialization.serialize_message(rect_image_ptr, &serialized_data_rect);
-  size_t rect_msg_size = serialized_data_rect.get_rcl_serialized_message().buffer_length;
+  size_t rect_msg_size = serialized_data_rect.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
 
   TRACEPOINT(
     image_proc_resize_cb_fini,

--- a/image_proc/src/resize_fpga.cpp
+++ b/image_proc/src/resize_fpga.cpp
@@ -131,13 +131,13 @@ void ResizeNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -333,13 +333,13 @@ void ResizeNodeFPGA::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
   const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
-  size_t out_msg_size = serialized_data_out.get_rcl_serialized_message().buffer_length;
+  size_t out_msg_size = serialized_data_out.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
 
 
   TRACEPOINT(

--- a/image_proc/src/resize_fpga.cpp
+++ b/image_proc/src/resize_fpga.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -122,22 +101,29 @@ ResizeNodeFPGA::ResizeNodeFPGA(const rclcpp::NodeOptions & options)
   OCL_CHECK(err, krnl_ = new cl::Kernel(program, "resize_accel", &err));
 }
 
-void ResizeNodeFPGA::imageCb(
-  sensor_msgs::msg::Image::ConstSharedPtr image_msg,
-  sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
-{
-    //Serialize the Image and CameraInfo messages
+size_t ResizeNodeFPGA::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
+  //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t ResizeNodeFPGA::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
+  return info_msg_size;
+}
+
+void ResizeNodeFPGA::imageCb(
+  sensor_msgs::msg::Image::ConstSharedPtr image_msg,
+  sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
+{
   
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -146,8 +132,8 @@ void ResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -157,8 +143,8 @@ void ResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -183,8 +169,8 @@ void ResizeNodeFPGA::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -328,19 +314,6 @@ void ResizeNodeFPGA::imageCb(
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_out;
-  rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
-  const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
-  out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
-  size_t out_msg_size = serialized_data_out.size();
-  
-  rclcpp::SerializedMessage serialized_data_dst_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
-  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
-  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.size();
-
 
   TRACEPOINT(
     image_proc_resize_cb_fini,
@@ -349,8 +322,8 @@ void ResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    out_msg_size,
-    dst_info_msg_size);
+    get_msg_size(output_image.toImageMsg()),
+    get_msg_size(dst_info_msg));
 
   // ///////////////////////////
   // // Validate, profile and benchmark

--- a/image_proc/src/resize_fpga.cpp
+++ b/image_proc/src/resize_fpga.cpp
@@ -225,9 +225,7 @@ void ResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
   // OpenCL section:
   cl_int err;
   size_t image_in_size_bytes, image_out_size_bytes;
@@ -326,21 +324,33 @@ void ResizeNodeFPGA::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
+
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_out;
+  rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
+  const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
+  out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
+  size_t out_msg_size = serialized_data_out.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_dst_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
+  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
+  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
+  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+
 
   TRACEPOINT(
     image_proc_resize_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
-    static_cast<const void *>(&(*info_msg)),
+    static_cast<const void *>(&(*output_image.toImageMsg())),
+    static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    out_msg_size,
+    dst_info_msg_size);
 
   // ///////////////////////////
   // // Validate, profile and benchmark

--- a/image_proc/src/resize_fpga_streamlined.cpp
+++ b/image_proc/src/resize_fpga_streamlined.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -102,6 +126,19 @@ void ResizeNodeFPGAStreamlined::imageCb(
   sensor_msgs::msg::Image::ConstSharedPtr image_msg,
   sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
 {
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   // std::cout << "ResizeNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -109,7 +146,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -118,7 +157,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -142,7 +183,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -183,7 +226,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
   // OpenCL section:
   cl_int err;
   size_t image_in_size_bytes, image_out_size_bytes;
@@ -271,7 +316,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
 
@@ -281,7 +328,9 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
 }
 

--- a/image_proc/src/resize_fpga_streamlined.cpp
+++ b/image_proc/src/resize_fpga_streamlined.cpp
@@ -131,13 +131,13 @@ void ResizeNodeFPGAStreamlined::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   // std::cout << "ResizeNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
@@ -323,13 +323,13 @@ void ResizeNodeFPGAStreamlined::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
   const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
-  size_t out_msg_size = serialized_data_out.get_rcl_serialized_message().buffer_length;
+  size_t out_msg_size = serialized_data_out.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
 
 
   TRACEPOINT(

--- a/image_proc/src/resize_fpga_streamlined.cpp
+++ b/image_proc/src/resize_fpga_streamlined.cpp
@@ -226,9 +226,7 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
   // OpenCL section:
   cl_int err;
   size_t image_in_size_bytes, image_out_size_bytes;
@@ -316,21 +314,33 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    image_msg->header.stamp.sec);
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
+
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_out;
+  rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
+  const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
+  out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
+  size_t out_msg_size = serialized_data_out.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_dst_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
+  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
+  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
+  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+
 
   TRACEPOINT(
     image_proc_resize_cb_fini,
     static_cast<const void *>(this),
-    static_cast<const void *>(&(*image_msg)),
-    static_cast<const void *>(&(*info_msg)),
+    static_cast<const void *>(&(*output_image.toImageMsg())),
+    static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    out_msg_size,
+    dst_info_msg_size);
 
 }
 

--- a/image_proc/src/resize_fpga_streamlined.cpp
+++ b/image_proc/src/resize_fpga_streamlined.cpp
@@ -1,28 +1,7 @@
 /*
-   @@@@@@@@@@@@@@@@@@@@
-   @@@@@@@@@&@@@&&@@@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@
-   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
-   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
-   @@@@@ @@  @@    @@@@ 
-   @@@@@@@@@&@@@@@@@@@@
-   @@@@@@@@@@@@@@@@@@@@
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. 
-*/
-
-/*
+    Modification Copyright (c) 2023, Acceleration Robotics®
+    Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+    Based on:
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -122,23 +101,30 @@ ResizeNodeFPGAStreamlined::ResizeNodeFPGAStreamlined(const rclcpp::NodeOptions &
   OCL_CHECK(err, krnl_ = new cl::Kernel(program, "resize_accel_streamlined", &err));
 }
 
-void ResizeNodeFPGAStreamlined::imageCb(
-  sensor_msgs::msg::Image::ConstSharedPtr image_msg,
-  sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
-{
+size_t ResizeNodeFPGAStreamlined::get_msg_size(sensor_msgs::msg::Image::ConstSharedPtr image_msg){
   //Serialize the Image and CameraInfo messages
   rclcpp::SerializedMessage serialized_data_img;
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
   size_t image_msg_size = serialized_data_img.size();
-  
+  return image_msg_size;
+}
+
+size_t ResizeNodeFPGAStreamlined::get_msg_size(sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg){
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
   size_t info_msg_size = serialized_data_info.size();
-  
+  return info_msg_size;
+}
+
+void ResizeNodeFPGAStreamlined::imageCb(
+  sensor_msgs::msg::Image::ConstSharedPtr image_msg,
+  sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
+{
+    
   // std::cout << "ResizeNodeFPGAStreamlined::imageCb" << std::endl;
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -147,8 +133,8 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    image_msg_size,
-    info_msg_size);
+    get_msg_size(image_msg),
+    get_msg_size(info_msg));
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -158,8 +144,8 @@ void ResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -184,8 +170,8 @@ void ResizeNodeFPGAStreamlined::imageCb(
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
       image_msg->header.stamp.sec,
-      image_msg_size,
-      info_msg_size);
+      get_msg_size(image_msg),
+      get_msg_size(info_msg));
     return;
   }
 
@@ -318,20 +304,6 @@ void ResizeNodeFPGAStreamlined::imageCb(
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
 
-  //Serialize the Image and CameraInfo messages
-  rclcpp::SerializedMessage serialized_data_out;
-  rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
-  const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
-  out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
-  size_t out_msg_size = serialized_data_out.size();
-  
-  rclcpp::SerializedMessage serialized_data_dst_info;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
-  const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
-  dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.size();
-
-
   TRACEPOINT(
     image_proc_resize_cb_fini,
     static_cast<const void *>(this),
@@ -339,8 +311,8 @@ void ResizeNodeFPGAStreamlined::imageCb(
     static_cast<const void *>(&(*dst_info_msg)),
     image_msg->header.stamp.nanosec,
     image_msg->header.stamp.sec,
-    out_msg_size,
-    dst_info_msg_size);
+    get_msg_size(output_image.toImageMsg()),
+    get_msg_size(dst_info_msg));
 
 }
 

--- a/image_proc/src/resize_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/resize_fpga_streamlined_xrt.cpp
@@ -1,4 +1,28 @@
 /*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
+/*
       ____  ____
      /   /\/   /
     /___/  \  /   Copyright (c) 2021, Xilinx®.
@@ -35,6 +59,7 @@
 #include "image_proc/xf_resize_config.h"
 #include "image_proc/resize_fpga_streamlined_xrt.hpp"
 #include "tracetools_image_pipeline/tracetools.h"
+#include <rclcpp/serialization.hpp>
 
 namespace image_proc
 {
@@ -74,6 +99,19 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
   sensor_msgs::msg::Image::ConstSharedPtr image_msg,
   sensor_msgs::msg::CameraInfo::ConstSharedPtr info_msg)
 {
+  //Serialize the Image and CameraInfo messages
+  rclcpp::SerializedMessage serialized_data_img;
+  rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
+  const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
+  image_serialization.serialize_message(image_ptr, &serialized_data_img);
+  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  
+  rclcpp::SerializedMessage serialized_data_info;
+  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
+  const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
+  info_serialization.serialize_message(info_ptr, &serialized_data_info);
+  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  
   // std::cout << "ResizeNodeFPGAStreamlinedXRT::imageCb XRT" << std::endl;
   TRACEPOINT(
     image_proc_resize_cb_init,
@@ -81,7 +119,9 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   if (pub_image_.getNumSubscribers() < 1) {
     TRACEPOINT(
@@ -90,7 +130,9 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
       static_cast<const void *>(&(*image_msg)),
       static_cast<const void *>(&(*info_msg)),
       image_msg->header.stamp.nanosec,
-      image_msg->header.stamp.sec);
+      image_msg->header.stamp.sec,
+      image_msg_size,
+      info_msg_size);
     return;
   }
 
@@ -149,7 +191,9 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   size_t image_out_size_count, image_out_size_bytes;
   if (gray) {
@@ -225,7 +269,9 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 
   pub_image_.publish(*output_image.toImageMsg(), *dst_info_msg);
 
@@ -235,7 +281,9 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
     static_cast<const void *>(&(*image_msg)),
     static_cast<const void *>(&(*info_msg)),
     image_msg->header.stamp.nanosec,
-    image_msg->header.stamp.sec);
+    image_msg->header.stamp.sec,
+    image_msg_size,
+    info_msg_size);
 }
 
 }  // namespace image_proc

--- a/image_proc/src/resize_fpga_streamlined_xrt.cpp
+++ b/image_proc/src/resize_fpga_streamlined_xrt.cpp
@@ -104,13 +104,13 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
   const void* image_ptr = reinterpret_cast<const void*>(image_msg.get());
   image_serialization.serialize_message(image_ptr, &serialized_data_img);
-  size_t image_msg_size = serialized_data_img.get_rcl_serialized_message().buffer_length;
+  size_t image_msg_size = serialized_data_img.size();
   
   rclcpp::SerializedMessage serialized_data_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> info_serialization;
   const void* info_ptr = reinterpret_cast<const void*>(info_msg.get());
   info_serialization.serialize_message(info_ptr, &serialized_data_info);
-  size_t info_msg_size = serialized_data_info.get_rcl_serialized_message().buffer_length;
+  size_t info_msg_size = serialized_data_info.size();
   
   // std::cout << "ResizeNodeFPGAStreamlinedXRT::imageCb XRT" << std::endl;
   TRACEPOINT(
@@ -276,13 +276,13 @@ void ResizeNodeFPGAStreamlinedXRT::imageCb(
   rclcpp::Serialization<sensor_msgs::msg::Image> out_image_serialization;
   const void* out_image_ptr = reinterpret_cast<const void*>(output_image.toImageMsg().get());
   out_image_serialization.serialize_message(out_image_ptr, &serialized_data_out);
-  size_t out_msg_size = serialized_data_out.get_rcl_serialized_message().buffer_length;
+  size_t out_msg_size = serialized_data_out.size();
   
   rclcpp::SerializedMessage serialized_data_dst_info;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> dst_info_serialization;
   const void* dst_info_ptr = reinterpret_cast<const void*>(dst_info_msg.get());
   dst_info_serialization.serialize_message(dst_info_ptr, &serialized_data_dst_info);
-  size_t dst_info_msg_size = serialized_data_dst_info.get_rcl_serialized_message().buffer_length;
+  size_t dst_info_msg_size = serialized_data_dst_info.size();
 
 
   TRACEPOINT(

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
@@ -114,9 +114,7 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, resize_image_msg_size_arg,
-    size_t, resize_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
@@ -124,8 +122,6 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
-    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -138,17 +134,13 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, resize_image_msg_size_arg,
-    size_t, resize_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
     ctf_integer_hex(const void *, resize_image_msg, resize_image_msg_arg)
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
-    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -210,17 +202,13 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, rectify_image_msg_size_arg,
-    size_t, rectify_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
-    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -233,17 +221,13 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, rectify_image_msg_size_arg,
-    size_t, rectify_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
-    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -305,17 +289,13 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, harris_image_msg_size_arg,
-    size_t, harris_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
     ctf_integer_hex(const void *, harris_image_msg, harris_image_msg_arg)
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
-    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -328,17 +308,13 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg,
-    size_t, harris_image_msg_size_arg,
-    size_t, harris_info_msg_size_arg),
+    uint32_t, image_input_header_sec_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
     ctf_integer_hex(const void *, harris_image_msg, harris_image_msg_arg)
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
-    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
-    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tp_call.h
@@ -1,3 +1,27 @@
+/*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
 // Copyright 2021 Víctor Mayoral-Vilches
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +66,9 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, resize_image_msg_size_arg,
+    size_t, resize_info_msg_size_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
@@ -50,6 +76,8 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
+    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -62,13 +90,17 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, resize_image_msg_size_arg,
+    size_t, resize_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
     ctf_integer_hex(const void *, resize_image_msg, resize_image_msg_arg)
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
+    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -82,7 +114,9 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, resize_image_msg_size_arg,
+    size_t, resize_info_msg_size_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
@@ -90,6 +124,8 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
+    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -102,13 +138,17 @@ TRACEPOINT_EVENT(
     const void *, resize_image_msg_arg,
     const void *, resize_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, resize_image_msg_size_arg,
+    size_t, resize_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, resize_node, resize_node_arg)
     ctf_integer_hex(const void *, resize_image_msg, resize_image_msg_arg)
     ctf_integer_hex(const void *, resize_info_msg, resize_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, resize_image_msg_size, resize_image_msg_size_arg)
+    ctf_integer(size_t, resize_info_msg_size, resize_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -123,7 +163,9 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
@@ -131,6 +173,8 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -143,13 +187,17 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -162,13 +210,17 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -181,13 +233,17 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -202,7 +258,9 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, harris_image_msg_size_arg,
+    size_t, harris_info_msg_size_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
@@ -210,6 +268,8 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
+    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -222,13 +282,17 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, harris_image_msg_size_arg,
+    size_t, harris_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
     ctf_integer_hex(const void *, harris_image_msg, harris_image_msg_arg)
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
+    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -241,13 +305,17 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, harris_image_msg_size_arg,
+    size_t, harris_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
     ctf_integer_hex(const void *, harris_image_msg, harris_image_msg_arg)
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
+    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -260,13 +328,17 @@ TRACEPOINT_EVENT(
     const void *, harris_image_msg_arg,
     const void *, harris_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, harris_image_msg_size_arg,
+    size_t, harris_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, harris_node, harris_node_arg)
     ctf_integer_hex(const void *, harris_image_msg, harris_image_msg_arg)
     ctf_integer_hex(const void *, harris_info_msg, harris_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, harris_image_msg_size, harris_image_msg_size_arg)
+    ctf_integer(size_t, harris_info_msg_size, harris_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -281,7 +353,9 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     // output event fields, see https://lttng.org/man/3/lttng-ust/v2.12/#doc-ctf-macros
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
@@ -289,6 +363,8 @@ TRACEPOINT_EVENT(
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )
@@ -301,13 +377,17 @@ TRACEPOINT_EVENT(
     const void *, rectify_image_msg_arg,
     const void *, rectify_info_msg_arg,
     uint32_t, image_input_header_nsec_arg,
-    uint32_t, image_input_header_sec_arg),
+    uint32_t, image_input_header_sec_arg,
+    size_t, rectify_image_msg_size_arg,
+    size_t, rectify_info_msg_size_arg),
   TP_FIELDS(
     ctf_integer_hex(const void *, rectify_node, rectify_node_arg)
     ctf_integer_hex(const void *, rectify_image_msg, rectify_image_msg_arg)
     ctf_integer_hex(const void *, rectify_info_msg, rectify_info_msg_arg)
     ctf_integer(uint32_t, image_input_header_nsec, image_input_header_nsec_arg)
     ctf_integer(uint32_t, image_input_header_sec, image_input_header_sec_arg)
+    ctf_integer(size_t, rectify_image_msg_size, rectify_image_msg_size_arg)
+    ctf_integer(size_t, rectify_info_msg_size, rectify_info_msg_size_arg)
     ctf_string(version, tracetools_image_pipeline_VERSION)
   )
 )

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
@@ -1,3 +1,27 @@
+/*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
 // Copyright 2021 Víctor Mayoral-Vilches
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,6 +94,8 @@ TRACETOOLS_PUBLIC bool ros_trace_compile_status();
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] image_input_image_msg_size size of image ROS message stored as bytes
+ * \param[in] image_input_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_cb_init,
@@ -77,7 +103,9 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size,
+  size_t harris_info_msg_size)
 
 /// `image_proc_harris_cb_fini`
 /**
@@ -90,6 +118,8 @@ DECLARE_TRACEPOINT(
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] harris_image_msg_size size of image ROS message stored as bytes
+ * \param[in] harris_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_cb_fini,
@@ -97,7 +127,9 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size,
+  size_t harris_info_msg_size)
 
 /// `image_proc_harris_init`
 /**
@@ -110,6 +142,8 @@ DECLARE_TRACEPOINT(
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] harris_image_msg_size size of image ROS message stored as bytes
+ * \param[in] harris_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_init,
@@ -117,7 +151,9 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size,
+  size_t harris_info_msg_size)
 
 /// `image_proc_harris_fini`
 /**
@@ -130,6 +166,8 @@ DECLARE_TRACEPOINT(
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] harris_image_msg_size size of image ROS message stored as bytes
+ * \param[in] harris_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_fini,
@@ -137,7 +175,9 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size,
+  size_t harris_info_msg_size)
 
 /// `image_proc_resize_cb_init`
 /**
@@ -150,6 +190,8 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
+ * \param[in] resize_image_msg_size size of image ROS message stored as bytes
+ * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_cb_init,
@@ -157,7 +199,9 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)  
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size,
+  size_t resize_info_msg_size)  
 
 /// `image_proc_resize_cb_fini`
 /**
@@ -170,6 +214,8 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] resize_image_msg_size size of image ROS message stored as bytes
+ * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_cb_fini,
@@ -177,7 +223,9 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size,
+  size_t resize_info_msg_size)
 
 /// `image_proc_resize_init`
 /**
@@ -190,6 +238,8 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] resize_image_msg_size size of image ROS message stored as bytes
+ * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_init,
@@ -197,7 +247,9 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size,
+  size_t resize_info_msg_size)
 
 /// `image_proc_resize_fini`
 /**
@@ -210,6 +262,8 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] resize_image_msg_size size of image ROS message stored as bytes
+ * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_fini,
@@ -217,7 +271,9 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size,
+  size_t resize_info_msg_size)
 
 /// `image_proc_rectify_cb_init`
 /**
@@ -230,6 +286,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_cb_init,
@@ -237,7 +295,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 /// `image_proc_rectify_cb_fini`
 /**
@@ -250,6 +310,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_cb_fini,
@@ -257,7 +319,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 /// `image_proc_rectify_init`
 /**
@@ -270,6 +334,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_init,
@@ -277,7 +343,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 /// `image_proc_rectify_fini`
 /**
@@ -290,6 +358,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_fini,
@@ -297,7 +367,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 /// `image_proc_rectify_resize_cb_init`
 /**
@@ -310,6 +382,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_resize_cb_init,
@@ -317,7 +391,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 /// `image_proc_rectify_resize_cb_fini`
 /**
@@ -330,6 +406,8 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
+ * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
+ * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_resize_cb_fini,
@@ -337,7 +415,9 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size,
+  size_t rectify_info_msg_size)
 
 #ifdef __cplusplus
 }

--- a/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
+++ b/tracetools_image_pipeline/include/tracetools_image_pipeline/tracetools.h
@@ -142,8 +142,6 @@ DECLARE_TRACEPOINT(
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
- * \param[in] harris_image_msg_size size of image ROS message stored as bytes
- * \param[in] harris_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_init,
@@ -151,9 +149,7 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t harris_image_msg_size,
-  size_t harris_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_harris_fini`
 /**
@@ -166,8 +162,6 @@ DECLARE_TRACEPOINT(
  * \param[in] harris_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
- * \param[in] harris_image_msg_size size of image ROS message stored as bytes
- * \param[in] harris_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_harris_fini,
@@ -175,9 +169,7 @@ DECLARE_TRACEPOINT(
   const void * harris_image_msg,
   const void * harris_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t harris_image_msg_size,
-  size_t harris_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_resize_cb_init`
 /**
@@ -238,8 +230,6 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
- * \param[in] resize_image_msg_size size of image ROS message stored as bytes
- * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_init,
@@ -247,9 +237,7 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t resize_image_msg_size,
-  size_t resize_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_resize_fini`
 /**
@@ -262,8 +250,6 @@ DECLARE_TRACEPOINT(
  * \param[in] resize_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
- * \param[in] resize_image_msg_size size of image ROS message stored as bytes
- * \param[in] resize_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_resize_fini,
@@ -271,9 +257,7 @@ DECLARE_TRACEPOINT(
   const void * resize_image_msg,
   const void * resize_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t resize_image_msg_size,
-  size_t resize_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_rectify_cb_init`
 /**
@@ -334,8 +318,6 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
- * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
- * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_init,
@@ -343,9 +325,7 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t rectify_image_msg_size,
-  size_t rectify_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_rectify_fini`
 /**
@@ -358,8 +338,6 @@ DECLARE_TRACEPOINT(
  * \param[in] rectify_info_msg info ROS message as sensor_msgs::msg::CameraInfo::ConstSharedPtr
  * \param[in] image_input_header_nsec_arg nanosec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message 
  * \param[in] image_input_header_sec_arg sec field of the header (std_msgs/Header) of sensor_msgs::msg::Image's ROS message  
- * \param[in] rectify_image_msg_size size of image ROS message stored as bytes
- * \param[in] rectify_info_msg_size size of info ROS message as bytes
  */
 DECLARE_TRACEPOINT(
   image_proc_rectify_fini,
@@ -367,9 +345,7 @@ DECLARE_TRACEPOINT(
   const void * rectify_image_msg,
   const void * rectify_info_msg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t rectify_image_msg_size,
-  size_t rectify_info_msg_size)
+  uint32_t image_input_header_sec_arg)
 
 /// `image_proc_rectify_resize_cb_init`
 /**

--- a/tracetools_image_pipeline/src/tracetools.c
+++ b/tracetools_image_pipeline/src/tracetools.c
@@ -1,3 +1,27 @@
+/*
+   @@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@&@@@&&@@@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@
+   @@@@@ @@  @@    @@@@ Copyright (c) 2023, Acceleration Robotics®
+   @@@@@ @@  @@    @@@@ Author: Alejandra Martínez Fariña <alex@accelerationrobotics.com>
+   @@@@@ @@  @@    @@@@ 
+   @@@@@@@@@&@@@@@@@@@@
+   @@@@@@@@@@@@@@@@@@@@
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+*/
+
 // Copyright 2021 Víctor Mayoral-Vilches
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +72,9 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size_arg,
+  size_t resize_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_cb_init,
@@ -56,7 +82,9 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    resize_image_msg_size_arg,
+    resize_info_msg_size_arg);
 
 }
 void TRACEPOINT(
@@ -65,7 +93,9 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size_arg,
+  size_t resize_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_cb_fini,
@@ -73,7 +103,9 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    resize_image_msg_size_arg,
+    resize_info_msg_size_arg);
 }
 void TRACEPOINT(
   image_proc_resize_init,
@@ -81,7 +113,9 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size_arg,
+  size_t resize_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_init,
@@ -89,7 +123,9 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    resize_image_msg_size_arg,
+    resize_info_msg_size_arg);
 }
 void TRACEPOINT(
   image_proc_resize_fini,
@@ -97,7 +133,9 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t resize_image_msg_size_arg,
+  size_t resize_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_fini,
@@ -105,7 +143,9 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    resize_image_msg_size_arg,
+    resize_info_msg_size_arg);
 }
 
 // rectify
@@ -115,7 +155,9 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_cb_init,
@@ -123,7 +165,9 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
 }
 void TRACEPOINT(
   image_proc_rectify_cb_fini,
@@ -131,7 +175,9 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_cb_fini,
@@ -139,7 +185,10 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg, 
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
+    
 }
 void TRACEPOINT(
   image_proc_rectify_init,
@@ -147,7 +196,9 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_init,
@@ -155,7 +206,9 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
 }
 void TRACEPOINT(
   image_proc_rectify_fini,
@@ -163,7 +216,10 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
+  
 {
   CONDITIONAL_TP(
     image_proc_rectify_fini,
@@ -171,7 +227,9 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
 }
 
 // harris
@@ -181,7 +239,9 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size_arg,
+  size_t harris_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_cb_init,
@@ -189,7 +249,9 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    harris_image_msg_size_arg,
+    harris_info_msg_size_arg);
 }
 
 void TRACEPOINT(
@@ -198,7 +260,9 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size_arg,
+  size_t harris_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_cb_fini,
@@ -206,7 +270,9 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    harris_image_msg_size_arg,
+    harris_info_msg_size_arg);
 }
 
 void TRACEPOINT(
@@ -215,7 +281,9 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size_arg,
+  size_t harris_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_init,
@@ -223,7 +291,9 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    harris_image_msg_size_arg,
+    harris_info_msg_size_arg);
 }
 
 void TRACEPOINT(
@@ -232,7 +302,9 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t harris_image_msg_size_arg,
+  size_t harris_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_fini,
@@ -240,7 +312,9 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    harris_image_msg_size_arg,
+    harris_info_msg_size_arg);
 }
 
 // rectify_resize
@@ -250,7 +324,9 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_resize_cb_init,
@@ -258,7 +334,9 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
 }
 
 void TRACEPOINT(
@@ -267,7 +345,9 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg)
+  uint32_t image_input_header_sec_arg,
+  size_t rectify_image_msg_size_arg,
+  size_t rectify_info_msg_size_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_resize_cb_fini,
@@ -275,7 +355,9 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg);
+    image_input_header_sec_arg,
+    rectify_image_msg_size_arg,
+    rectify_info_msg_size_arg);
 }
 
 #ifndef _WIN32

--- a/tracetools_image_pipeline/src/tracetools.c
+++ b/tracetools_image_pipeline/src/tracetools.c
@@ -113,9 +113,7 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t resize_image_msg_size_arg,
-  size_t resize_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_init,
@@ -123,9 +121,7 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    resize_image_msg_size_arg,
-    resize_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 void TRACEPOINT(
   image_proc_resize_fini,
@@ -133,9 +129,7 @@ void TRACEPOINT(
   const void * resize_image_msg_arg,
   const void * resize_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t resize_image_msg_size_arg,
-  size_t resize_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
 {
   CONDITIONAL_TP(
     image_proc_resize_fini,
@@ -143,9 +137,7 @@ void TRACEPOINT(
     resize_image_msg_arg,
     resize_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    resize_image_msg_size_arg,
-    resize_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 
 // rectify
@@ -196,9 +188,7 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t rectify_image_msg_size_arg,
-  size_t rectify_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
 {
   CONDITIONAL_TP(
     image_proc_rectify_init,
@@ -206,9 +196,7 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    rectify_image_msg_size_arg,
-    rectify_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 void TRACEPOINT(
   image_proc_rectify_fini,
@@ -216,9 +204,7 @@ void TRACEPOINT(
   const void * rectify_image_msg_arg,
   const void * rectify_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t rectify_image_msg_size_arg,
-  size_t rectify_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
   
 {
   CONDITIONAL_TP(
@@ -227,9 +213,7 @@ void TRACEPOINT(
     rectify_image_msg_arg,
     rectify_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    rectify_image_msg_size_arg,
-    rectify_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 
 // harris
@@ -281,9 +265,7 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t harris_image_msg_size_arg,
-  size_t harris_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_init,
@@ -291,9 +273,7 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    harris_image_msg_size_arg,
-    harris_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 
 void TRACEPOINT(
@@ -302,9 +282,7 @@ void TRACEPOINT(
   const void * harris_image_msg_arg,
   const void * harris_info_msg_arg,
   uint32_t image_input_header_nsec_arg,
-  uint32_t image_input_header_sec_arg,
-  size_t harris_image_msg_size_arg,
-  size_t harris_info_msg_size_arg)
+  uint32_t image_input_header_sec_arg)
 {
   CONDITIONAL_TP(
     image_proc_harris_fini,
@@ -312,9 +290,7 @@ void TRACEPOINT(
     harris_image_msg_arg,
     harris_info_msg_arg,
     image_input_header_nsec_arg,
-    image_input_header_sec_arg,
-    harris_image_msg_size_arg,
-    harris_info_msg_size_arg);
+    image_input_header_sec_arg);
 }
 
 // rectify_resize


### PR DESCRIPTION
Associated with: [Issue #26](https://github.com/robotperf/benchmarks/issues/26#issue-1710047991) 
and [PR #36](https://github.com/robotperf/benchmarks/pull/36#issue-1724237315) in robotperf/benchmarks

List of existent packages affected:
- tracetools_image_pipeline:
  - [x] tracetools.h: added two new fields for the tracepoint (image and camera_info msgs size)
  - [x] tp_call.h: added two new fields for the tracepoint (image and camera_info msgs size)
  - [x] tracetools.c: added two new fields for the tracepoint (image and camera_info msgs size)
 
- image_proc:
   - [x] in .hpp files: added get_msg_size method declaration for image and camera info messages
   - [x] in .cpp files: 
     - added get_msg_size method definition for image and camera info messages serialization
     - added two new fields for the tracepoint (image and camera_info msgs size)
   