### PR TITLE
Merge stereo_image_proc package from upstream

### DIFF
--- a/stereo_image_proc/CHANGELOG.rst
+++ b/stereo_image_proc/CHANGELOG.rst
@@ -1,3 +1,29 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package stereo_image_proc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+3.0.0 (2022-04-29)
+------------------
+* Fix the tests for stereo_image_proc.
+* Cleanup stereo_image_proc
+* Populate CameraInfo camera matrix in test fixture
+* Use with_default_policies
+* Improve formatting
+* Use SubscriptionOptions
+* Add subscriber qos overrides
+* Remove QosPolicyKind::Invalid
+* Allow QoS overrides for publishers
+* Add missing test dependency
+* Add color param to stereo_image_proc (`#661 <https://github.com/ros-perception/image_pipeline/issues/661>`_)
+* changes per comments
+* fix for stereo_image_proc_tests
+* Add maintainer (`#667 <https://github.com/ros-perception/image_pipeline/issues/667>`_)
+* Add disparity node parameters to launch file
+* Fix disparity node parameter name
+* Expose avoid_point_cloud_padding parameter in stereo_image_proc launch file (`#599 <https://github.com/ros-perception/image_pipeline/issues/599>`_)
+* Refactor image_proc and stereo_image_proc launch files (`#583 <https://github.com/ros-perception/image_pipeline/issues/583>`_)
+* Contributors: Audrow Nash, Chris Lalancette, Jacob Perron, Patrick Musau, Rebecca Butler
+
 2.2.1 (2020-08-27)
 ------------------
 * remove email blasts from steve macenski (`#596 <https://github.com/ros-perception/image_pipeline/issues/596>`_)

--- a/stereo_image_proc/include/stereo_image_proc/stereo_processor.hpp
+++ b/stereo_image_proc/include/stereo_image_proc/stereo_processor.hpp
@@ -29,16 +29,18 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef STEREO_IMAGE_PROC__STEREO_PROCESSOR_HPP_
 #define STEREO_IMAGE_PROC__STEREO_PROCESSOR_HPP_
 
-#include <image_geometry/stereo_camera_model.h>
+#include <string>
+
+#include "image_geometry/stereo_camera_model.h"
+
 #include <image_proc/processor.hpp>
 #include <sensor_msgs/msg/point_cloud.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <stereo_msgs/msg/disparity_image.hpp>
-
-#include <string>
 
 namespace stereo_image_proc
 {

--- a/stereo_image_proc/launch/stereo_image_proc.launch.py
+++ b/stereo_image_proc/launch/stereo_image_proc.launch.py
@@ -40,6 +40,7 @@ from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.actions import PushRosNamespace
@@ -215,7 +216,12 @@ def generate_launch_description():
         SetLaunchConfiguration(
             condition=LaunchConfigurationEquals('container', ''),
             name='container',
-            value='stereo_image_proc_container'
+            value=PythonExpression([
+                '"stereo_image_proc_container"', ' if ',
+                '"', LaunchConfiguration('ros_namespace', default=''), '"',
+                ' == "" else ', '"',
+                LaunchConfiguration('ros_namespace', default=''), '/stereo_image_proc_container"'
+            ]),
         ),
         GroupAction(
             [

--- a/stereo_image_proc/package.xml
+++ b/stereo_image_proc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>stereo_image_proc</name>
-  <version>2.2.1</version>
+  <version>3.0.0</version>
   <description>Stereo and single image rectification and disparity processing.</description>
 
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>

--- a/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/disparity_node.cpp
@@ -29,22 +29,6 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <stereo_image_proc/stereo_processor.hpp>
-
-#include <cv_bridge/cv_bridge.h>
-#include <image_geometry/stereo_camera_model.h>
-#include <image_transport/image_transport.hpp>
-#include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-#include <sensor_msgs/image_encodings.hpp>
-#include <stereo_msgs/msg/disparity_image.hpp>
-
-#include <opencv2/calib3d/calib3d.hpp>
 
 #include <algorithm>
 #include <map>
@@ -53,6 +37,24 @@
 #include <sstream>
 #include <utility>
 #include <vector>
+
+#include "cv_bridge/cv_bridge.h"
+#include "image_geometry/stereo_camera_model.h"
+#include "message_filters/subscriber.h"
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/approximate_time.h"
+#include "message_filters/sync_policies/exact_time.h"
+
+#include <stereo_image_proc/stereo_processor.hpp>
+
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <stereo_msgs/msg/disparity_image.hpp>
+
+#include <opencv2/calib3d/calib3d.hpp>
 
 namespace stereo_image_proc
 {
@@ -265,7 +267,10 @@ DisparityNode::DisparityNode(const rclcpp::NodeOptions & options)
   this->declare_parameters("", double_params);
   this->declare_parameters("", bool_params);
 
-  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1);
+  // Update the publisher options to allow reconfigurable qos settings.
+  rclcpp::PublisherOptions pub_opts;
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  pub_disparity_ = create_publisher<stereo_msgs::msg::DisparityImage>("disparity", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.
@@ -283,10 +288,14 @@ void DisparityNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  sub_l_image_.subscribe(this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos);
-  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
-  sub_r_image_.subscribe(this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos);
-  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
+  auto sub_opts = rclcpp::SubscriptionOptions();
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  sub_l_image_.subscribe(
+    this, "left/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_r_image_.subscribe(
+    this, "right/image_rect", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
 }
 
 void DisparityNode::imageCb(

--- a/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/point_cloud_node.cpp
@@ -29,24 +29,26 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <image_geometry/stereo_camera_model.h>
-#include <image_transport/image_transport.hpp>
-#include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-#include <rcutils/logging_macros.h>
-#include <sensor_msgs/image_encodings.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <stereo_msgs/msg/disparity_image.hpp>
 
 #include <limits>
 #include <memory>
 #include <string>
+
+#include "image_geometry/stereo_camera_model.h"
+#include "message_filters/subscriber.h"
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/approximate_time.h"
+#include "message_filters/sync_policies/exact_time.h"
+#include "rcutils/logging_macros.h"
+
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <stereo_msgs/msg/disparity_image.hpp>
 
 namespace stereo_image_proc
 {
@@ -130,7 +132,10 @@ PointCloudNode::PointCloudNode(const rclcpp::NodeOptions & options)
       std::bind(&PointCloudNode::imageCb, this, _1, _2, _3, _4));
   }
 
-  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1);
+  // Update the publisher options to allow reconfigurable qos settings.
+  rclcpp::PublisherOptions pub_opts;
+  pub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  pub_points2_ = create_publisher<sensor_msgs::msg::PointCloud2>("points2", 1, pub_opts);
 
   // TODO(jacobperron): Replace this with a graph event.
   //                    Only subscribe if there's a subscription listening to our publisher.
@@ -148,10 +153,13 @@ void PointCloudNode::connectCb()
     image_sub_qos = rclcpp::SystemDefaultsQoS();
   }
   const auto image_sub_rmw_qos = image_sub_qos.get_rmw_qos_profile();
-  sub_l_image_.subscribe(this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos);
-  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos);
-  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos);
-  sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos);
+  auto sub_opts = rclcpp::SubscriptionOptions();
+  sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  sub_l_image_.subscribe(
+    this, "left/image_rect_color", hints.getTransport(), image_sub_rmw_qos, sub_opts);
+  sub_l_info_.subscribe(this, "left/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_r_info_.subscribe(this, "right/camera_info", image_sub_rmw_qos, sub_opts);
+  sub_disparity_.subscribe(this, "disparity", image_sub_rmw_qos, sub_opts);
 }
 
 inline bool isValidPoint(const cv::Vec3f & pt)

--- a/stereo_image_proc/src/stereo_image_proc/stereo_processor.cpp
+++ b/stereo_image_proc/src/stereo_image_proc/stereo_processor.cpp
@@ -29,14 +29,16 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "stereo_image_proc/stereo_processor.hpp"
-
-#include <rcutils/logging_macros.h>
-#include <sensor_msgs/image_encodings.hpp>
 
 #include <cmath>
 #include <limits>
 #include <string>
+
+#include "rcutils/logging_macros.h"
+
+#include "stereo_image_proc/stereo_processor.hpp"
+
+#include <sensor_msgs/image_encodings.hpp>
 
 // TODO(jacobperron): Remove this after it's implemented upstream
 // https://github.com/ros2/rcutils/pull/112

--- a/stereo_image_proc/test/fixtures/disparity_image_publisher.py
+++ b/stereo_image_proc/test/fixtures/disparity_image_publisher.py
@@ -75,7 +75,7 @@ class DisparityImagePublisher(Node):
         self.disparity_image = DisparityImage()
         self.disparity_image.image.height = disparity_image.shape[0]
         self.disparity_image.image.width = disparity_image.shape[1]
-        self.disparity_image.image.step = self.disparity_image.image.width
+        self.disparity_image.image.step = self.disparity_image.image.width * 4
         self.disparity_image.image.data = array.array('B', disparity_image.tobytes())
 
         self.left_image_pub = self.create_publisher(Image, 'left/image_rect_color', 1)

--- a/stereo_image_proc/test/fixtures/stereo_image_publisher.py
+++ b/stereo_image_proc/test/fixtures/stereo_image_publisher.py
@@ -90,6 +90,11 @@ class StereoImagePublisher(Node):
         camera_info_msg = CameraInfo()
         camera_info_msg.height = image.shape[0]
         camera_info_msg.width = image.shape[1]
+        camera_info_msg.p = [
+            1.0, 0.0, 1.0, 0.0,
+            0.0, 1.0, 1.0, 0.0,
+            0.0, 0.0, 1.0, 0.0
+        ]
 
         return (image_msg, camera_info_msg)
 

--- a/stereo_image_proc/test/test_disparity_node.py
+++ b/stereo_image_proc/test/test_disparity_node.py
@@ -74,7 +74,7 @@ def generate_test_description():
             executable='disparity_node',
             name='disparity_node',
             parameters=[
-                {"use_system_default_qos": True}
+                {'use_system_default_qos': True}
             ],
             output='screen'
         ),


### PR DESCRIPTION
* I've realized up until now I had been using the deb-based `stereo_image_proc` package when reproducing [`a3_stereo_image_proc`](https://github.com/robotperf/benchmarks/tree/main/benchmarks/perception/a3_stereo_image_proc). I had `ros-acceleration/image_pipeline` fork on my workspace, but there's a `COLCON_IGNORE` in `stereo_image_proc`. Thus, `colcon` was taking it from `opt/ros/humble`.
* I had to uninstall the deb-based `image_proc` package (due to [this](https://github.com/ros-acceleration/image_pipeline/pull/3#issuecomment-1562471836)).
* Now I have unsuccessfully tried to compile `a3` only with this fork.
* This PR manually merges the `ros-perception/stereo_image_proc` directory, making `a3` compilation possible from our fork.